### PR TITLE
Support for amd64 on osx

### DIFF
--- a/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -15,7 +15,7 @@ public abstract class Platform {
                     platform = new Windows();
                 } else if (osName.contains("linux")) {
                     platform = new Linux();
-                } else if (osName.contains("os x") && (arch.equals("i386") || arch.equals("x86_64"))) {
+                } else if (osName.contains("os x") && (arch.equals("i386") || arch.equals("x86_64") || arch.equals("amd64"))) {
                     platform = new OsX();
                 } else if (osName.contains("sunos")) {
                     platform = new Solaris();


### PR DESCRIPTION
Hi adam,
I ran into problems using the native-platform on osx with opendjk 1.7 and oracle jvm 1.7 as they use amd64 as architecture description instead of x86_64 as the macosx jvm 1.6 does. I've added 'amd64' to the supported architectures in the Platform class
