### PR TITLE
Allow depending only on the variants which can be built locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,10 @@ dependencies {
     testImplementation 'org.spockframework:spock-core:1.0-groovy-2.4'
 }
 
+// Only depend on variants which can be built on our CI
 boolean onlyPrimaryVariants = project.hasProperty("onlyPrimaryVariants")
+// Only depend on variants which can be built on the current machine
+boolean onlyLocalVariants = project.hasProperty("onlyLocalVariants")
 
 def generatedFilesDir = file("$buildDir/generated")
 
@@ -293,10 +296,8 @@ model {
             }
 
             binaries.withType(SharedLibraryBinarySpec) { binary ->
-                def targetOs = binary.targetPlatform.operatingSystem
-                def targetArch = binary.targetPlatform.architecture
-                def includeVariant = !onlyPrimaryVariants || targetOs.windows || targetOs.macOsX || (targetOs.linux && targetArch.name == "x86-64" && !targetPlatform.name.contains("ncurses6"))
-                if (!includeVariant) {
+                def includeVariant = !onlyPrimaryVariants || canBeBuiltOnCi(binary.targetPlatform)
+                if (!includeVariant || (onlyLocalVariants && !buildable)) {
                     return
                 }
                 def variantName = targetPlatform.name.replace('_', '-')
@@ -381,4 +382,14 @@ String inferNCursesVersion(def os) {
         }
     }
     throw new IllegalArgumentException("Could not determine ncurses version installed on this machine.")
+}
+
+boolean canBeBuiltOnCi(NativePlatform targetPlatform) {
+    def targetOs = targetPlatform.operatingSystem
+    // Can build all Windows & Mac variants on CI
+    if (targetOs.windows || targetOs.macOsX) {
+        return true
+    }
+    // Can only build the 64bit ncurses5 variant on Linux
+    return targetPlatform.architecture.name == "x86-64" && !targetPlatform.name.contains("ncurses6")
 }


### PR DESCRIPTION
So a working version can be published to the local Maven repository
and used from another build.