### PR TITLE
Publish FreeBSD variant from CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,8 +393,14 @@ boolean canBeBuiltOnCi(NativePlatform targetPlatform) {
     if (targetOs.windows || targetOs.macOsX) {
         return true
     }
+    if (targetPlatform.architecture.name != "x86-64") {
+        return false
+    }
+    if (targetOs.freeBSD) {
+        return targetPlatform.name.contains("libcpp")
+    }
     // Can only build the 64bit ncurses5 variant on Linux
-    return targetOs.linux && targetPlatform.architecture.name == "x86-64" && !targetPlatform.name.contains("ncurses6")
+    return targetOs.linux && !targetPlatform.name.contains("ncurses6")
 }
 
 String binaryToVariantName(NativeBinarySpec binary) {


### PR DESCRIPTION
Now that there are FreeBSD agents, we also can publish the variant from CI.