### PR TITLE
Free strings used to call back to Java from native threads

### DIFF
--- a/src/main/cpp/apple_fsnotifier.cpp
+++ b/src/main/cpp/apple_fsnotifier.cpp
@@ -221,7 +221,9 @@ void Server::handleEvent(JNIEnv *env, char* path, FSEventStreamEventFlags flags)
 
     log_fine(env, "Changed: %s %d", path, type);
 
-    env->CallVoidMethod(watcherCallback, watcherCallbackMethod, type, env->NewStringUTF(path));
+    jstring javaPath = env->NewStringUTF(path);
+    env->CallVoidMethod(watcherCallback, watcherCallbackMethod, type, javaPath);
+    env->DeleteLocalRef(javaPath);
 }
 
 static JNIEnv* lookupThreadEnv(JavaVM *jvm) {

--- a/src/main/cpp/win_fsnotifier.cpp
+++ b/src/main/cpp/win_fsnotifier.cpp
@@ -366,6 +366,7 @@ void Server::reportEvent(jint type, const wstring changedPath) {
     jclass callback_class = env->GetObjectClass(watcherCallback);
     jmethodID methodCallback = env->GetMethodID(callback_class, "pathChanged", "(ILjava/lang/String;)V");
     env->CallVoidMethod(watcherCallback, methodCallback, type, changedPathJava);
+    env->DeleteLocalRef(changedPathJava);
 }
 
 static void CALLBACK requestTerminationCallback(_In_ ULONG_PTR arg) {

--- a/src/shared/cpp/generic.cpp
+++ b/src/shared/cpp/generic.cpp
@@ -31,6 +31,9 @@ void mark_failed_with_code(JNIEnv *env, const char* message, int error_code, con
     jstring error_code_str = error_code_message == NULL ? NULL : env->NewStringUTF(error_code_message);
     jint failure_code = map_error_code(error_code);
     env->CallVoidMethod(result, method, message_str, failure_code, error_code, error_code_str);
+    if (error_code_str != NULL) {
+        env->DeleteLocalRef(error_code_str);
+    }
 }
 
 JNIEnv* attach_jni(JavaVM* jvm, char *name, bool daemon) {

--- a/src/shared/cpp/generic_posix.cpp
+++ b/src/shared/cpp/generic_posix.cpp
@@ -88,7 +88,9 @@ void printlog(JNIEnv* env, int level, const char* fmt, ...) {
     if (env == NULL) {
         fprintf(stderr, "%s\n", buffer);
     } else {
-        env->CallStaticVoidMethod(clsLogger, logMethod, level, env->NewStringUTF(buffer));
+        jstring logString = env->NewStringUTF(buffer);
+        env->CallStaticVoidMethod(clsLogger, logMethod, level, logString);
+        env->DeleteLocalRef(logString);
     }
 }
 

--- a/src/shared/cpp/win.cpp
+++ b/src/shared/cpp/win.cpp
@@ -124,7 +124,9 @@ void printlog(JNIEnv* env, int level, const wchar_t* fmt, ...) {
     if (env == nullptr) {
         fwprintf(stderr, L"!!! %ls\n", buffer);
     } else {
-        env->CallStaticVoidMethod(clsLogger, logMethod, level, wchar_to_java(env, buffer, wcslen(buffer), NULL));
+        jstring logString = wchar_to_java(env, buffer, wcslen(buffer), NULL);
+        env->CallStaticVoidMethod(clsLogger, logMethod, level, logString);
+        env->DeleteLocalRef(logString);
     }
 }
 


### PR DESCRIPTION
Since the logging may be called from a native thread,
the String needs to be freed. If not, the log messages
will not be garbage collected.

This fixes a memory leak exposed by the soak test in `gradle/gradle`: https://github.com/gradle/gradle/pull/12253