### PR TITLE
Remove support for 32bit and stdcpp

### DIFF
--- a/.teamcity/NativePlatformPublishing.kt
+++ b/.teamcity/NativePlatformPublishing.kt
@@ -68,7 +68,7 @@ open class NativePlatformPublishSnapshot(releaseType: ReleaseType, uploadTasks: 
         uploadTasks.forEach { task ->
             gradle {
                 name = "Gradle $task"
-                tasks = "clean $task $buildScanInit -P${releaseType.gradleProperty}${if (releaseType.userProvidedVersion) "=%versionPostfix%" else ""} -PonlyPrimaryVariants -PbintrayUserName=%ARTIFACTORY_USERNAME% -PbintrayApiKey=%ARTIFACTORY_PASSWORD%"
+                tasks = "clean $task $buildScanInit -P${releaseType.gradleProperty}${if (releaseType.userProvidedVersion) "=%versionPostfix%" else ""} -PbintrayUserName=%ARTIFACTORY_USERNAME% -PbintrayApiKey=%ARTIFACTORY_PASSWORD%"
                 buildFile = ""
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,6 @@ dependencies {
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 
-// Only depend on variants which can be built on our CI
-boolean onlyPrimaryVariants = project.hasProperty("onlyPrimaryVariants")
 // Only depend on variants which can be built on the current machine
 boolean onlyLocalVariants = project.hasProperty("onlyLocalVariants")
 
@@ -101,18 +99,6 @@ model {
             architecture "amd64"
             operatingSystem "osx"
         }
-        linux_i386 {
-            architecture "i386"
-            operatingSystem "linux"
-        }
-        linux_i386_ncurses5 {
-            architecture "i386"
-            operatingSystem "linux"
-        }
-        linux_i386_ncurses6 {
-            architecture "i386"
-            operatingSystem "linux"
-        }
         linux_amd64 {
             architecture "amd64"
             operatingSystem "linux"
@@ -153,19 +139,7 @@ model {
             architecture "amd64"
             operatingSystem "windows"
         }
-        freebsd_i386_libcpp {
-            architecture "i386"
-            operatingSystem "freebsd"
-        }
-        freebsd_i386_libstdcpp {
-            architecture "i386"
-            operatingSystem "freebsd"
-        }
         freebsd_amd64_libcpp {
-            architecture "amd64"
-            operatingSystem "freebsd"
-        }
-        freebsd_amd64_libstdcpp {
             architecture "amd64"
             operatingSystem "freebsd"
         }
@@ -302,8 +276,7 @@ model {
             }
 
             binaries.withType(SharedLibraryBinarySpec) { binary ->
-                def includeVariant = !onlyPrimaryVariants || canBeBuiltOnCi(binary.targetPlatform)
-                if (!includeVariant || (onlyLocalVariants && !buildable)) {
+                if (onlyLocalVariants && !buildable) {
                     return
                 }
                 def variantName = binaryToVariantName(binary)
@@ -396,25 +369,6 @@ String inferNCursesVersion(def os) {
         }
     }
     throw new IllegalArgumentException("Could not determine ncurses version installed on this machine.")
-}
-
-boolean canBeBuiltOnCi(NativePlatform targetPlatform) {
-    def targetOs = targetPlatform.operatingSystem
-    // Can build all Windows & Mac variants on CI
-    if (targetOs.windows || targetOs.macOsX) {
-        return true
-    }
-    if (targetPlatform.architecture.name == "aarch64") {
-        return targetOs.linux
-    }
-    if (targetPlatform.architecture.name != "x86-64") {
-        return false
-    }
-    if (targetOs.freeBSD) {
-        return targetPlatform.name.contains("libcpp")
-    }
-    // Can only build the 64bit variants on Linux
-    return targetOs.linux
 }
 
 String binaryToVariantName(NativeBinarySpec binary) {

--- a/readme.md
+++ b/readme.md
@@ -78,10 +78,10 @@ See [WindowsRegistry](src/main/java/net/rubygrapefruit/platform/WindowsRegistry.
 Currently ported to OS X, Linux, FreeBSD and Windows. Support for Solaris is a work in progress. Supported on:
 
 * OS X, version 10.9 and later (x86_64)
-* Fedora 23 and later (amd64, i386).
-* Ubuntu 8.04 and later (amd64, i386).
+* Fedora 23 and later (amd64).
+* Ubuntu 8.04 and later (amd64).
 * Ubuntu 18.04 and later (aarch64).
-* FreeBSD 8.4 and later (amd64, i386).
+* FreeBSD 10 and later (amd64).
 * Windows XP and later (amd64, i386). Console integration works with cmd.exe, powershell, ConEmu, Mintty from Cygwin, Mintty from Msys (includes Git for Windows).
 
 ## Using
@@ -119,6 +119,10 @@ Some sample code to use the terminal:
     System.out.println("bold text");
 
 ## Changes
+
+### 0.22 (unreleased)
+
+* Remove support for 32bit Linux & FreeBSD, as well as support for FreeBSD < 10.
 
 ### 0.21
 


### PR DESCRIPTION
So all variants can be built on CI.

Given that most Linux OSes are dropping 32bit support, it seems safe to remove the 32bit support. Same goes for stdlib support for FreeBSD, given that the GCC toolchain was deprecated in FreeBSD 10

Replaces #65.