### PR TITLE
Register each watched path individually on macOS

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -27,7 +27,7 @@ WatchPoint::WatchPoint(Server* server, CFRunLoopRef runLoop, const u16string& pa
     }
     CFMutableArrayRef pathArray = CFArrayCreateMutable(NULL, 1, NULL);
     if (pathArray == NULL) {
-        throw FileWatcherException("Could not allocate array to store roots to watch");
+        throw FileWatcherException("Could not allocate array to store root to watch");
     }
     CFArrayAppendValue(pathArray, cfPath);
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -86,7 +86,9 @@ Server::Server(JNIEnv* env, jobject watcherCallback, jobjectArray rootsToWatch, 
 }
 
 Server::~Server() {
-    if (threadLoop != NULL) {
+    watchPoints.clear();
+
+    if (threadLoop != NULL && CFRunLoopIsWaiting(threadLoop)) {
         CFRunLoopStop(threadLoop);
     }
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -20,7 +20,7 @@ struct deletable_facet : Facet {
     }
 };
 
-EventStream::EventStream(Server* server, CFRunLoopRef runLoop, CFStringRef path, long latencyInMillis) {
+WatchPoint::WatchPoint(Server* server, CFRunLoopRef runLoop, CFStringRef path, long latencyInMillis) {
     CFMutableArrayRef pathArray = CFArrayCreateMutable(NULL, 1, NULL);
     if (pathArray == NULL) {
         throw FileWatcherException("Could not allocate array to store roots to watch");
@@ -51,7 +51,7 @@ EventStream::EventStream(Server* server, CFRunLoopRef runLoop, CFStringRef path,
     this->watcherStream = watcherStream;
 }
 
-EventStream::~EventStream() {
+WatchPoint::~WatchPoint() {
     // Reading the Apple docs it seems we should call FSEventStreamFlushSync() here.
     // But doing so produces this log:
     //

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -89,8 +89,6 @@ Server::~Server() {
 }
 
 void Server::runLoop(JNIEnv* env, function<void()> notifyStarted) {
-    log_fine(env, "Starting thread", NULL);
-
     CFRunLoopRef threadLoop = CFRunLoopGetCurrent();
     eventStream.schedule(this, threadLoop);
     this->threadLoop = threadLoop;
@@ -100,8 +98,6 @@ void Server::runLoop(JNIEnv* env, function<void()> notifyStarted) {
     CFRunLoopRun();
 
     eventStream.unschedule();
-
-    log_fine(env, "Stopping thread", NULL);
 }
 
 static void handleEventsCallback(

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -46,10 +46,14 @@ void AbstractServer::startThread() {
 void AbstractServer::run() {
     JNIEnv* env = attach_jni(jvm, "File watcher server", true);
 
+    log_fine(env, "Starting thread", NULL);
+
     runLoop(env, [this] {
         unique_lock<mutex> lock(watcherThreadMutex);
         watcherThreadStarted.notify_all();
     });
+
+    log_fine(env, "Stopping thread", NULL);
 
     detach_jni(jvm);
 }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -156,8 +156,8 @@ Server::Server(JNIEnv* env, jobject watcherCallback)
 Server::~Server() {
 }
 
-void Server::runLoop(JNIEnv* env, function<void()> notifyStarted) {
-    notifyStarted();
+void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
+    notifyStarted(nullptr);
 
     while (!terminate || watchPoints.size() > 0) {
         SleepEx(INFINITE, true);

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -157,15 +157,11 @@ Server::~Server() {
 }
 
 void Server::runLoop(JNIEnv* env, function<void()> notifyStarted) {
-    log_info(env, "Server thread %d with handle %p running", GetCurrentThreadId(), watcherThread.native_handle());
-
     notifyStarted();
 
     while (!terminate || watchPoints.size() > 0) {
         SleepEx(INFINITE, true);
     }
-
-    log_info(env, "Server thread %d finishing", GetCurrentThreadId());
 }
 
 void Server::startWatching(JNIEnv* env, const u16string& path) {

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -51,6 +51,7 @@ private:
     const long latencyInMillis;
 
     CFRunLoopRef threadLoop;
+    CFRunLoopTimerRef keepAlive;
 };
 
 #endif

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -21,7 +21,7 @@ static void handleEventsCallback(
 
 class WatchPoint {
 public:
-    WatchPoint(Server* server, CFRunLoopRef runLoop, CFStringRef path, long latencyInMillis);
+    WatchPoint(Server* server, CFRunLoopRef runLoop, const u16string& path, long latencyInMillis);
     ~WatchPoint();
 
 private:

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -5,6 +5,7 @@
 #include "generic_fsnotifier.h"
 #include "net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions.h"
 #include <CoreServices/CoreServices.h>
+#include <list>
 
 using namespace std;
 
@@ -20,19 +21,19 @@ static void handleEventsCallback(
 
 class EventStream {
 public:
-    EventStream(Server* server, CFRunLoopRef runLoop, CFArrayRef rootsToWatch, long latencyInMillis);
+    EventStream(Server* server, CFRunLoopRef runLoop, CFStringRef path, long latencyInMillis);
     ~EventStream();
 
 private:
     FSEventStreamRef watcherStream;
-    Server* server;
 };
 
 class Server : AbstractServer {
 public:
-    Server(JNIEnv* env, jobject watcherCallback, CFArrayRef rootsToWatch, long latencyInMillis);
+    Server(JNIEnv* env, jobject watcherCallback, jobjectArray rootsToWatch, long latencyInMillis);
     ~Server();
 
+    void startWatching(CFStringRef path, long latencyInMillis);
     void handleEvents(
         size_t numEvents,
         char** eventPaths,
@@ -45,7 +46,8 @@ protected:
 private:
     void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);
 
-    const CFArrayRef rootsToWatch;
+    const jobjectArray rootsToWatch;
+    list<EventStream> watchPoints;
     const long latencyInMillis;
 
     CFRunLoopRef threadLoop;

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -20,21 +20,10 @@ static void handleEventsCallback(
 
 class EventStream {
 public:
-    EventStream(CFArrayRef rootsToWatch, long latencyInMillis);
+    EventStream(Server* server, CFRunLoopRef runLoop, CFArrayRef rootsToWatch, long latencyInMillis);
     ~EventStream();
 
-    void schedule(Server* server, CFRunLoopRef runLoop);
-    void unschedule();
-
 private:
-    friend void handleEventsCallback(
-        ConstFSEventStreamRef streamRef,
-        void* clientCallBackInfo,
-        size_t numEvents,
-        void* eventPaths,
-        const FSEventStreamEventFlags eventFlags[],
-        const FSEventStreamEventId eventIds[]);
-
     FSEventStreamRef watcherStream;
     Server* server;
 };
@@ -51,12 +40,14 @@ public:
         const FSEventStreamEventId eventIds[]);
 
 protected:
-    void runLoop(JNIEnv* env, function<void()> notifyStarted) override;
+    void runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) override;
 
 private:
     void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);
 
-    EventStream eventStream;
+    const CFArrayRef rootsToWatch;
+    const long latencyInMillis;
+
     CFRunLoopRef threadLoop;
 };
 

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -30,10 +30,10 @@ private:
 
 class Server : AbstractServer {
 public:
-    Server(JNIEnv* env, jobject watcherCallback, jobjectArray rootsToWatch, long latencyInMillis);
+    Server(JNIEnv* env, jobject watcherCallback);
     ~Server();
 
-    void startWatching(CFStringRef path, long latencyInMillis);
+    void startWatching(const u16string& path, long latencyInMillis);
     void handleEvents(
         size_t numEvents,
         char** eventPaths,
@@ -46,10 +46,7 @@ protected:
 private:
     void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);
 
-    const jobjectArray rootsToWatch;
     list<WatchPoint> watchPoints;
-    const long latencyInMillis;
-
     CFRunLoopRef threadLoop;
     CFRunLoopTimerRef keepAlive;
 };

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -19,10 +19,10 @@ static void handleEventsCallback(
     const FSEventStreamEventFlags eventFlags[],
     const FSEventStreamEventId eventIds[]);
 
-class EventStream {
+class WatchPoint {
 public:
-    EventStream(Server* server, CFRunLoopRef runLoop, CFStringRef path, long latencyInMillis);
-    ~EventStream();
+    WatchPoint(Server* server, CFRunLoopRef runLoop, CFStringRef path, long latencyInMillis);
+    ~WatchPoint();
 
 private:
     FSEventStreamRef watcherStream;
@@ -47,7 +47,7 @@ private:
     void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);
 
     const jobjectArray rootsToWatch;
-    list<EventStream> watchPoints;
+    list<WatchPoint> watchPoints;
     const long latencyInMillis;
 
     CFRunLoopRef threadLoop;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "logging.h"
+#include <exception>
 #include <functional>
 #include <mutex>
 #include <thread>
@@ -42,7 +43,7 @@ protected:
     void reportChange(JNIEnv* env, int type, const u16string& path);
 
     void startThread();
-    virtual void runLoop(JNIEnv* env, function<void()> notifyStarted) = 0;
+    virtual void runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) = 0;
 
     thread watcherThread;
 
@@ -50,6 +51,7 @@ private:
     void run();
     mutex watcherThreadMutex;
     condition_variable watcherThreadStarted;
+    exception_ptr initException;
 
     jobject watcherCallback;
     jmethodID watcherCallbackMethod;

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -65,7 +65,7 @@ public:
     void close(JNIEnv* env);
 
 protected:
-    void Server::runLoop(JNIEnv* env, function<void()> notifyStarted) override;
+    void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) override;
 
 private:
     list<WatchPoint*> watchPoints;

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -13,9 +13,6 @@ import java.util.List;
 
 public class AbstractFileEventFunctions implements NativeIntegration {
     protected FileWatcher createWatcher(Collection<String> paths, FileWatcherCallback callback, WatcherFactory starter) {
-        if (paths.isEmpty()) {
-            return FileWatcher.EMPTY;
-        }
         List<String> canonicalPaths = canonicalizeAbsolutePaths(paths);
         return starter.createWatcher(
             canonicalPaths.toArray(new String[0]),

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
@@ -59,6 +59,14 @@ abstract class AbstractFileEventsTest extends Specification {
         LOGGER.info("<<< Finished '${testName.methodName}'")
     }
 
+    def "can start and stop watcher without watching any paths"() {
+        when:
+        startWatcher()
+
+        then:
+        noExceptionThrown()
+    }
+
     def "can open and close watcher on a directory without receiving any events"() {
         when:
         startWatcher(rootDir)


### PR DESCRIPTION
This is to make it work more similarly to the Windows watcher. Doing this will make it easier to start and stop watching things dynamically.