### PR TITLE
Do not pass `FunctionResult` objects to JNI calls

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -200,7 +200,7 @@ Server* startWatching(JNIEnv* env, jclass target, jobjectArray paths, long laten
 }
 
 JNIEXPORT jobject JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatching(JNIEnv* env, jclass target, jobjectArray paths, long latencyInMillis, jobject javaCallback, jobject result) {
+Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatching(JNIEnv* env, jclass target, jobjectArray paths, long latencyInMillis, jobject javaCallback) {
     Server* server;
     try {
         server = startWatching(env, target, paths, latencyInMillis, javaCallback);
@@ -221,7 +221,7 @@ Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatchin
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_stopWatching(JNIEnv* env, jclass target, jobject detailsObj, jobject result) {
+Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_stopWatching(JNIEnv* env, jclass target, jobject detailsObj) {
     Server* server = (Server*) env->GetDirectBufferAddress(detailsObj);
     assert(server != NULL);
     delete server;

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -279,7 +279,7 @@ void convertToLongPathIfNeeded(u16string& path) {
 //
 
 JNIEXPORT jobject JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatching(JNIEnv* env, jclass target, jobjectArray paths, jobject javaCallback, jobject result) {
+Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatching(JNIEnv* env, jclass target, jobjectArray paths, jobject javaCallback) {
     Server* server = new Server(env, javaCallback);
 
     int watchPointCount = env->GetArrayLength(paths);
@@ -302,7 +302,7 @@ Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWat
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_stopWatching(JNIEnv* env, jclass target, jobject detailsObj, jobject result) {
+Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_stopWatching(JNIEnv* env, jclass target, jobject detailsObj) {
     Server* server = (Server*) env->GetDirectBufferAddress(detailsObj);
     server->close(env);
     delete server;

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -18,7 +18,6 @@ package net.rubygrapefruit.platform.internal.jni;
 
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.file.FileWatcherCallback;
-import net.rubygrapefruit.platform.internal.FunctionResult;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -64,15 +63,15 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
     public FileWatcher startWatching(Collection<String> paths, final long latency, final TimeUnit unit, FileWatcherCallback callback) {
         return createWatcher(paths, callback, new WatcherFactory() {
             @Override
-            public FileWatcher createWatcher(String[] canonicalPaths, NativeFileWatcherCallback callback, FunctionResult result) {
-                return startWatching(canonicalPaths, unit.toMillis(latency), callback, result);
+            public FileWatcher createWatcher(String[] canonicalPaths, NativeFileWatcherCallback callback) {
+                return startWatching(canonicalPaths, unit.toMillis(latency), callback);
             }
         });
     }
 
-    private static native FileWatcher startWatching(String[] paths, long latencyInMillis, NativeFileWatcherCallback callback, FunctionResult result);
+    private static native FileWatcher startWatching(String[] paths, long latencyInMillis, NativeFileWatcherCallback callback);
 
-    private static native void stopWatching(Object details, FunctionResult result);
+    private static native void stopWatching(Object details);
 
     // Created from native code
     @SuppressWarnings("unused")
@@ -82,8 +81,8 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
         }
 
         @Override
-        protected void stop(Object details, FunctionResult result) {
-            stopWatching(details, result);
+        protected void stop(Object details) {
+            stopWatching(details);
         }
     }
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -18,7 +18,6 @@ package net.rubygrapefruit.platform.internal.jni;
 
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.file.FileWatcherCallback;
-import net.rubygrapefruit.platform.internal.FunctionResult;
 
 import java.util.Collection;
 
@@ -57,15 +56,15 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
     public FileWatcher startWatching(Collection<String> paths, FileWatcherCallback callback) {
         return createWatcher(paths, callback, new WatcherFactory() {
             @Override
-            public FileWatcher createWatcher(String[] canonicalPaths, NativeFileWatcherCallback callback, FunctionResult result) {
-                return startWatching(canonicalPaths, callback, result);
+            public FileWatcher createWatcher(String[] canonicalPaths, NativeFileWatcherCallback callback) {
+                return startWatching(canonicalPaths, callback);
             }
         });
     }
 
-    private static native FileWatcher startWatching(String[] paths, NativeFileWatcherCallback callback, FunctionResult result);
+    private static native FileWatcher startWatching(String[] paths, NativeFileWatcherCallback callback);
 
-    private static native void stopWatching(Object details, FunctionResult result);
+    private static native void stopWatching(Object details);
 
     // Created from native code
     @SuppressWarnings("unused")
@@ -75,8 +74,8 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
         }
 
         @Override
-        protected void stop(Object details, FunctionResult result) {
-            stopWatching(details, result);
+        protected void stop(Object details) {
+            stopWatching(details);
         }
     }
 }


### PR DESCRIPTION
We are now throwing exceptions from the native side now.