### PR TITLE
Handle empty file name received in event notification on Windows

### DIFF
--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -88,7 +88,7 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
                 log_fine(env, "Finished watching '%s'", utf16ToUtf8String(path).c_str());
                 return;
             default:
-                throw FileWatcherException("Error received when handling events", errorCode);
+                throw FileWatcherException("Error received when handling events", path, errorCode);
         }
 
         if (bytesTransferred == 0) {
@@ -168,11 +168,10 @@ void convertToLongPathIfNeeded(u16string& path) {
 void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info) {
     wstring changedPathW = wstring(info->FileName, 0, info->FileNameLength / sizeof(wchar_t));
     u16string changedPath(changedPathW.begin(), changedPathW.end());
-    // TODO Do we ever get an empty path?
     if (!changedPath.empty()) {
         changedPath.insert(0, 1, u'\\');
-        changedPath.insert(0, path);
     }
+    changedPath.insert(0, path);
     // TODO Remove long prefix for path once?
     if (isLongPath(changedPath)) {
         if (isUncLongPath(changedPath)) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
@@ -733,7 +733,11 @@ abstract class AbstractFileEventsTest extends Specification {
 
         @Override
         void pathChanged(Type type, String path) {
-            handleEvent(new FileEvent(type, new File(path), true))
+            def changed = new File(path)
+            if (!changed.absolute) {
+                throw new IllegalArgumentException("Received non-absolute changed path: " + path);
+            }
+            handleEvent(new FileEvent(type, changed, true))
         }
 
         @Override


### PR DESCRIPTION
It is unclear when we should receive an event with an empty file name (maybe when the watched directory itself is changed?), and why these things started to cause `StringIndexOutOfBoundsException` (or whether they are the culprit). However, this case needs to be handled, so here's a fix.

I'm also strengthening our tests by checking if the reported change is an absolute path and failing the test if it isn't.