### PR TITLE
Make inotify non-blocking

### DIFF
--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -36,7 +36,7 @@ void WatchPoint::close() {
 }
 
 Inotify::Inotify()
-    : fd(inotify_init1(IN_CLOEXEC)) {
+    : fd(inotify_init1(IN_CLOEXEC | IN_NONBLOCK)) {
     if (fd == -1) {
         throw FileWatcherException("Couldn't register inotify handle", errno);
     }


### PR DESCRIPTION
Apparently even after `poll()` has returned `POLLIN` for the `inotify` file descriptor, it is possible for `read()` to block:

See https://github.com/gradle/gradle/issues/12457#issuecomment-597070255:

```text
Thread 35 (Thread 0x7f0cc5895700 (LWP 14458)):
#0  0x00007f0d7b3a451d in read () at ../sysdeps/unix/syscall-template.S:84
#1  0x00007f0cc5e680fd in Server::handleEvents (this=0x7f0ce4ccfff0) at /home/tcagent1/agent/work/419e0e7240c3cf05/src/file-events/cpp/linux_fsnotifier.cpp:139
#2  0x00007f0cc5e68000 in Server::processQueues (this=0x7f0ce4ccfff0, timeout=2147483647) at /home/tcagent1/agent/work/419e0e7240c3cf05/src/file-events/cpp/linux_fsnotifier.cpp:128
#3  0x00007f0cc5e67e96 in Server::runLoop(JNIEnv_*, std::function<void (std::__exception_ptr::exception_ptr)>) (this=0x7f0ce4ccfff0, notifyStarted=...)
    at /home/tcagent1/agent/work/419e0e7240c3cf05/src/file-events/cpp/linux_fsnotifier.cpp:104
#4  0x00007f0cc5e70848 in AbstractServer::run (this=0x7f0ce4ccfff0) at /home/tcagent1/agent/work/419e0e7240c3cf05/src/file-events/cpp/generic_fsnotifier.cpp:130
...
```

This happened during shutdown.

Hopefully making the `inotify` non-blocking can help resolve this. We don't currently have a test in `native-platform` to reproduce the above problem.