### PR TITLE
Wait for cancelled watch point to be finished on Linux

### DIFF
--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -291,7 +291,7 @@ void Server::unregisterPath(const u16string& path) {
     watchPoint.cancel();
     processQueues(CLOSE_TIMEOUT_IN_MS);
     if (watchPoint.status != FINISHED) {
-        log_warning(getThreadEnv(), "Could not cancel watch point %s", utf16ToUtf8String(path).c_str());
+        throw FileWatcherException("Could not cancel watch point %s", path);
     } else {
         watchRoots.erase(watchPoint.watchDescriptor);
         watchPoints.erase(path);

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -289,6 +289,8 @@ void Server::unregisterPath(const u16string& path) {
     }
     auto& watchPoint = it->second;
     watchPoint.cancel();
+    // Make sure we handle the cancellation
+    processQueues(0);
 }
 
 JNIEXPORT jobject JNICALL

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -25,9 +25,6 @@ using namespace std;
 #define IS_SET(flags, flag) (((flags) & (flag)) == (flag))
 #define IS_ANY_SET(flags, mask) (((flags) & (mask)) != 0)
 
-// TODO Make this parametrizable perhaps
-#define SERVER_CLOSE_TIMEOUT_IN_MS 1000
-
 struct FileWatcherException : public runtime_error {
 public:
     FileWatcherException(const string& message, const u16string& path, int errorCode);

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -12,6 +12,9 @@
 
 using namespace std;
 
+// TODO Make this parametrizable perhaps
+#define CLOSE_TIMEOUT_IN_MS 1000
+
 class Server;
 
 struct Inotify {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
@@ -596,8 +596,10 @@ abstract class AbstractFileEventsTest extends Specification {
         given:
         def createdFile = new File(rootDir, "created.txt")
         startWatcher(rootDir)
-        watcher.stopWatching(rootDir)
-        watcher.startWatching(rootDir)
+        100.times {
+            watcher.stopWatching(rootDir)
+            watcher.startWatching(rootDir)
+        }
 
         when:
         def expectedChanges = expectEvents event(CREATED, createdFile)


### PR DESCRIPTION
Fixes a problem when we stop and start watching the same directory in quick succession on Linux.