### PR TITLE
Load `NativeException` class when we start the server

### DIFF
--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -202,6 +202,10 @@ void AbstractServer::reportChange(JNIEnv* env, int type, const u16string& path) 
 
 void AbstractServer::reportError(JNIEnv* env, const exception& exception) {
     jclass exceptionClass = env->FindClass("net/rubygrapefruit/platform/NativeException");
+    if (exceptionClass == nullptr) {
+        log_severe(env, "Cannot report exception - can't load NativeException. Exception: %s", exception.what());
+        return;
+    }
     assert(exceptionClass != nullptr);
     u16string message = utf8ToUtf16String(exception.what());
     jstring javaMessage = env->NewString((jchar*) message.c_str(), (jsize) message.length());

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -93,46 +93,7 @@ void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
         processQueues(forever);
     }
 
-    log_fine(env, "Finished with run loop, now cancelling remaining watch points", NULL);
-    int pendingWatchPoints = 0;
-    for (auto& it : watchPoints) {
-        auto& watchPoint = it.second;
-        switch (watchPoint.status) {
-            case LISTENING:
-                try {
-                    if (watchPoint.cancel()) {
-                        pendingWatchPoints++;
-                    }
-                } catch (const exception& ex) {
-                    reportError(env, ex);
-                }
-                break;
-            case CANCELLED:
-                pendingWatchPoints++;
-                break;
-            default:
-                break;
-        }
-    }
-
-    // If there are any pending watchers, wait for them to finish
-    if (pendingWatchPoints > 0) {
-        log_fine(env, "Waiting for %d pending watch points to finish", pendingWatchPoints);
-        processQueues(CLOSE_TIMEOUT_IN_MS);
-    }
-
-    // Warn about  any unfinished watchpoints
-    for (auto& it : watchPoints) {
-        auto& watchPoint = it.second;
-        switch (watchPoint.status) {
-            case FINISHED:
-                break;
-            default:
-                log_warning(env, "Watch point %s did not finish before termination timeout, status = %d",
-                    utf16ToUtf8String(watchPoint.path).c_str(), watchPoint.status);
-                break;
-        }
-    }
+    log_fine(env, "Finished with run loop", NULL);
 }
 
 void Server::processQueues(int timeout) {

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -59,8 +59,8 @@ class AbstractServer;
 
 class Command {
 public:
-    Command(){};
-    virtual ~Command(){};
+    Command() {};
+    virtual ~Command() {};
 
     void execute(AbstractServer* server) {
         try {
@@ -141,6 +141,7 @@ private:
     jmethodID watcherReportErrorMethod;
 
     JavaVM* jvm;
+    jclass nativeExceptionClass;
 };
 
 class RegisterPathCommand : public Command {


### PR DESCRIPTION
Under some circumstances, we seem to be unable to load the class when trying to close the server and fail when trying to report an exception to the Java side.

See https://stackoverflow.com/questions/20752352/classnotfoundexception-when-finding-a-class-in-jni-background-thread
and https://stackoverflow.com/questions/13263340/findclass-from-any-thread-in-android-jni
for reasons which might cause the problem.