### PR TITLE
Load exception class via JNI_OnLoad

### DIFF
--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -186,13 +186,11 @@ void AbstractServer::reportChange(JNIEnv* env, int type, const u16string& path) 
         string message = javaToUtf8String(env, javaMessage);
         env->DeleteLocalRef(javaMessage);
 
-        jclass classClass = env->FindClass("java/lang/Class");
-        jmethodID getClassName = env->GetMethodID(classClass, "getName", "()Ljava/lang/String;");
+        jmethodID getClassName = env->GetMethodID(jniConstants->classClass, "getName", "()Ljava/lang/String;");
         jstring javaExceptionType = (jstring) env->CallObjectMethod(exceptionClass, getClassName);
         string exceptionType = javaToUtf8String(env, javaExceptionType);
         env->DeleteLocalRef(javaExceptionType);
 
-        env->DeleteLocalRef(classClass);
         env->DeleteLocalRef(exceptionClass);
         env->DeleteLocalRef(exception);
 
@@ -273,9 +271,8 @@ jobject wrapServer(JNIEnv* env, function<void*()> serverStarter) {
         return rethrowAsJavaException(env, e);
     }
 
-    jclass clsWatcher = env->FindClass("net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions$NativeFileWatcher");
-    jmethodID constructor = env->GetMethodID(clsWatcher, "<init>", "(Ljava/lang/Object;)V");
-    return env->NewObject(clsWatcher, constructor, env->NewDirectByteBuffer(server, sizeof(server)));
+    jmethodID constructor = env->GetMethodID(jniConstants->nativeFileWatcherClass, "<init>", "(Ljava/lang/Object;)V");
+    return env->NewObject(jniConstants->nativeFileWatcherClass, constructor, env->NewDirectByteBuffer(server, sizeof(server)));
 }
 
 JNIEXPORT void JNICALL
@@ -318,11 +315,15 @@ static jclass findClass(JNIEnv* env, const char* className) {
 }
 
 JniConstants::JniConstants(JNIEnv* env)
-    : nativeExceptionClass(findClass(env, "net/rubygrapefruit/platform/NativeException")) {
+    : nativeExceptionClass(findClass(env, "net/rubygrapefruit/platform/NativeException"))
+    , classClass(findClass(env, "java/lang/Class"))
+    , nativeFileWatcherClass(findClass(env, "net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions$NativeFileWatcher")) {
 }
 
 void JniConstants::unload(JNIEnv* env) {
     env->DeleteGlobalRef(nativeExceptionClass);
+    env->DeleteGlobalRef(classClass);
+    env->DeleteGlobalRef(nativeFileWatcherClass);
 }
 
 JNIEXPORT jint JNICALL

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -5,6 +5,8 @@
 
 #include "generic_fsnotifier.h"
 
+static JniConstants* jniConstants;
+
 class JNIThread {
 public:
     JNIThread(JavaVM* jvm, const char* name, bool daemon) {

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -5,7 +5,7 @@
 
 #include "generic_fsnotifier.h"
 
-static JniConstants* jniConstants;
+JniConstants* jniConstants;
 
 class JNIThread {
 public:

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -178,6 +178,12 @@ public:
     }
 };
 
+struct JniConstants {
+    static void init(JNIEnv* env);
+
+    static jclass nativeExceptionClass;
+};
+
 string javaToUtf8String(JNIEnv* env, jstring javaString);
 
 u16string javaToUtf16String(JNIEnv* env, jstring javaString);

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -187,8 +187,6 @@ struct JniConstants {
     const jclass nativeFileWatcherClass;
 };
 
-static JniConstants* jniConstants;
-
 string javaToUtf8String(JNIEnv* env, jstring javaString);
 
 u16string javaToUtf16String(JNIEnv* env, jstring javaString);

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -183,6 +183,8 @@ struct JniConstants {
     void unload(JNIEnv* env);
 
     const jclass nativeExceptionClass;
+    const jclass classClass;
+    const jclass nativeFileWatcherClass;
 };
 
 static JniConstants* jniConstants;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -59,8 +59,8 @@ class AbstractServer;
 
 class Command {
 public:
-    Command(){};
-    virtual ~Command(){};
+    Command() {};
+    virtual ~Command() {};
 
     void execute(AbstractServer* server) {
         try {
@@ -179,10 +179,13 @@ public:
 };
 
 struct JniConstants {
-    static void init(JNIEnv* env);
+    JniConstants(JNIEnv* env);
+    void unload(JNIEnv* env);
 
-    static jclass nativeExceptionClass;
+    const jclass nativeExceptionClass;
 };
+
+static JniConstants* jniConstants;
 
 string javaToUtf8String(JNIEnv* env, jstring javaString);
 

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -187,6 +187,8 @@ struct JniConstants {
     const jclass nativeFileWatcherClass;
 };
 
+extern JniConstants* jniConstants;
+
 string javaToUtf8String(JNIEnv* env, jstring javaString);
 
 u16string javaToUtf16String(JNIEnv* env, jstring javaString);


### PR DESCRIPTION
so all threads can access it and don't fall back to
the system classloader.