### PR TITLE
Logging, take 2

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -105,7 +105,7 @@ Server::~Server() {
     CFRelease(messageSource);
 }
 
-void Server::runLoop(JNIEnv*, function<void(exception_ptr)> notifyStarted) {
+void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
     try {
         CFRunLoopRef threadLoop = CFRunLoopGetCurrent();
         this->threadLoop = threadLoop;
@@ -156,7 +156,7 @@ void Server::handleEvents(
 }
 
 void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags) {
-    log_fine(env, "Event flags: 0x%x for %s", flags, path);
+    log_fine("Event flags: 0x%x for %s", flags, path);
 
     jint type;
     if (IS_SET(flags, kFSEventStreamEventFlagHistoryDone)) {
@@ -186,11 +186,11 @@ void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags)
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemCreated)) {
         type = FILE_EVENT_CREATED;
     } else {
-        log_warning(env, "Unknown event 0x%x for %s", flags, path);
+        log_warning("Unknown event 0x%x for %s", flags, path);
         type = FILE_EVENT_UNKNOWN;
     }
 
-    log_fine(env, "Changed: %s %d", path, type);
+    log_fine("Changed: %s %d", path, type);
     u16string pathStr = utf8ToUtf16String(path);
     reportChange(env, type, pathStr);
 }
@@ -206,7 +206,7 @@ void Server::registerPath(const u16string& path) {
 
 void Server::unregisterPath(const u16string& path) {
     if (watchPoints.erase(path) == 0) {
-        log_fine(getThreadEnv(), "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        log_fine("Path is not watched: %s", utf16ToUtf8String(path).c_str());
     }
 }
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -156,7 +156,7 @@ void Server::handleEvents(
 }
 
 void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags) {
-    log_fine("Event flags: 0x%x for %s", flags, path);
+    log(FINE, "Event flags: 0x%x for %s", flags, path);
 
     jint type;
     if (IS_SET(flags, kFSEventStreamEventFlagHistoryDone)) {
@@ -186,11 +186,11 @@ void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags)
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemCreated)) {
         type = FILE_EVENT_CREATED;
     } else {
-        log_warning("Unknown event 0x%x for %s", flags, path);
+        log(WARNING, "Unknown event 0x%x for %s", flags, path);
         type = FILE_EVENT_UNKNOWN;
     }
 
-    log_fine("Changed: %s %d", path, type);
+    log(FINE, "Changed: %s %d", path, type);
     u16string pathStr = utf8ToUtf16String(path);
     reportChange(env, type, pathStr);
 }
@@ -206,7 +206,7 @@ void Server::registerPath(const u16string& path) {
 
 void Server::unregisterPath(const u16string& path) {
     if (watchPoints.erase(path) == 0) {
-        log_fine("Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        log(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
     }
 }
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -156,7 +156,7 @@ void Server::handleEvents(
 }
 
 void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags) {
-    log(FINE, "Event flags: 0x%x for %s", flags, path);
+    logToJava(FINE, "Event flags: 0x%x for %s", flags, path);
 
     jint type;
     if (IS_SET(flags, kFSEventStreamEventFlagHistoryDone)) {
@@ -186,11 +186,11 @@ void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags)
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemCreated)) {
         type = FILE_EVENT_CREATED;
     } else {
-        log(WARNING, "Unknown event 0x%x for %s", flags, path);
+        logToJava(WARNING, "Unknown event 0x%x for %s", flags, path);
         type = FILE_EVENT_UNKNOWN;
     }
 
-    log(FINE, "Changed: %s %d", path, type);
+    logToJava(FINE, "Changed: %s %d", path, type);
     u16string pathStr = utf8ToUtf16String(path);
     reportChange(env, type, pathStr);
 }
@@ -206,7 +206,7 @@ void Server::registerPath(const u16string& path) {
 
 void Server::unregisterPath(const u16string& path) {
     if (watchPoints.erase(path) == 0) {
-        log(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
     }
 }
 

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -83,22 +83,20 @@ void AbstractServer::startThread() {
 
 void AbstractServer::run() {
     JniThreadAttacher jniThread(jvm, "File watcher server", true);
-    JNIEnv* env = getThreadEnv();
-
-    log_fine(env, "Starting thread", NULL);
+    log_fine("Starting thread", NULL);
 
     try {
-        runLoop(env, [this](exception_ptr initException) {
+        runLoop([this](exception_ptr initException) {
             unique_lock<mutex> lock(watcherThreadMutex);
             this->initException = initException;
             watcherThreadStarted.notify_all();
-            log_fine(getThreadEnv(), "Started thread", NULL);
+            log_fine("Started thread", NULL);
         });
     } catch (const exception& ex) {
-        reportError(env, ex);
+        reportError(getThreadEnv(), ex);
     }
 
-    log_fine(env, "Stopping thread", NULL);
+    log_fine("Stopping thread", NULL);
 }
 
 void AbstractServer::executeOnThread(shared_ptr<Command> command) {
@@ -204,7 +202,7 @@ AbstractServer* getServer(JNIEnv* env, jobject javaServer) {
 }
 
 jobject rethrowAsJavaException(JNIEnv* env, const exception& e) {
-    log_severe(env, "Caught exception: %s", e.what());
+    log_severe("Caught exception: %s", e.what());
     jint ret = env->ThrowNew(jniConstants->nativeExceptionClass, e.what());
     if (ret != 0) {
         fprintf(stderr, "JNI ThrowNew returned %d when rethrowing native exception: %s\n", ret, e.what());

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -255,10 +255,12 @@ JniConstants::JniConstants(JavaVM* jvm)
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM* jvm, void*) {
     jniConstants = new JniConstants(jvm);
+    logging = new Logging(jvm);
     return JNI_VERSION_1_6;
 }
 
 JNIEXPORT void JNICALL
 JNI_OnUnload(JavaVM*, void*) {
+    delete logging;
     delete jniConstants;
 }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -256,14 +256,6 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
     }
 }
 
-jclass JniConstants::findClass(const char* className) {
-    JNIEnv* env = getThreadEnv();
-    jclass localRef = env->FindClass(className);
-    jclass globalRef = reinterpret_cast<jclass>(env->NewGlobalRef(localRef));
-    env->DeleteLocalRef(localRef);
-    return globalRef;
-}
-
 JniConstants::JniConstants(JavaVM* jvm)
     : JniSupport(jvm)
     , nativeExceptionClass(findClass("net/rubygrapefruit/platform/NativeException"))

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -5,8 +5,6 @@
 
 #include "generic_fsnotifier.h"
 
-JniConstants* jniConstants;
-
 inline string createMessage(const string& message, const u16string& path) {
     stringstream ss;
     ss << message;
@@ -250,17 +248,4 @@ JniConstants::JniConstants(JavaVM* jvm)
     , nativeExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/NativeException")
     , classClass(getThreadEnv(), "java/lang/Class")
     , nativeFileWatcherClass(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions$NativeFileWatcher") {
-}
-
-JNIEXPORT jint JNICALL
-JNI_OnLoad(JavaVM* jvm, void*) {
-    jniConstants = new JniConstants(jvm);
-    logging = new Logging(jvm);
-    return JNI_VERSION_1_6;
-}
-
-JNIEXPORT void JNICALL
-JNI_OnUnload(JavaVM*, void*) {
-    delete logging;
-    delete jniConstants;
 }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -243,6 +243,10 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
     }
 }
 
+JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_invalidateLogLevelCache(JNIEnv*, jobject) {
+    logging->invalidateLogLevelCache();
+}
+
 JniConstants::JniConstants(JavaVM* jvm)
     : JniSupport(jvm)
     , nativeExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/NativeException")

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -72,20 +72,20 @@ void AbstractServer::startThread() {
 
 void AbstractServer::run() {
     JniThreadAttacher jniThread(jvm, "File watcher server", true);
-    log(FINE, "Starting thread", NULL);
+    logToJava(FINE, "Starting thread", NULL);
 
     try {
         runLoop([this](exception_ptr initException) {
             unique_lock<mutex> lock(watcherThreadMutex);
             this->initException = initException;
             watcherThreadStarted.notify_all();
-            log(FINE, "Started thread", NULL);
+            logToJava(FINE, "Started thread", NULL);
         });
     } catch (const exception& ex) {
         reportError(getThreadEnv(), ex);
     }
 
-    log(FINE, "Stopping thread", NULL);
+    logToJava(FINE, "Stopping thread", NULL);
 }
 
 void AbstractServer::executeOnThread(shared_ptr<Command> command) {
@@ -191,7 +191,7 @@ AbstractServer* getServer(JNIEnv* env, jobject javaServer) {
 }
 
 jobject rethrowAsJavaException(JNIEnv* env, const exception& e) {
-    log(SEVERE, "Caught exception: %s", e.what());
+    logToJava(SEVERE, "Caught exception: %s", e.what());
     jint ret = env->ThrowNew(jniConstants->nativeExceptionClass.get(), e.what());
     if (ret != 0) {
         fprintf(stderr, "JNI ThrowNew returned %d when rethrowing native exception: %s\n", ret, e.what());

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -194,7 +194,7 @@ jobject rethrowAsJavaException(JNIEnv* env, const exception& e) {
     logToJava(SEVERE, "Caught exception: %s", e.what());
     jint ret = env->ThrowNew(jniConstants->nativeExceptionClass.get(), e.what());
     if (ret != 0) {
-        fprintf(stderr, "JNI ThrowNew returned %d when rethrowing native exception: %s\n", ret, e.what());
+        cerr << "JNI ThrowNew returned %d when rethrowing native exception: " << ret << endl;
     }
     return NULL;
 }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -83,20 +83,20 @@ void AbstractServer::startThread() {
 
 void AbstractServer::run() {
     JniThreadAttacher jniThread(jvm, "File watcher server", true);
-    log_fine("Starting thread", NULL);
+    log(FINE, "Starting thread", NULL);
 
     try {
         runLoop([this](exception_ptr initException) {
             unique_lock<mutex> lock(watcherThreadMutex);
             this->initException = initException;
             watcherThreadStarted.notify_all();
-            log_fine("Started thread", NULL);
+            log(FINE, "Started thread", NULL);
         });
     } catch (const exception& ex) {
         reportError(getThreadEnv(), ex);
     }
 
-    log_fine("Stopping thread", NULL);
+    log(FINE, "Stopping thread", NULL);
 }
 
 void AbstractServer::executeOnThread(shared_ptr<Command> command) {
@@ -202,7 +202,7 @@ AbstractServer* getServer(JNIEnv* env, jobject javaServer) {
 }
 
 jobject rethrowAsJavaException(JNIEnv* env, const exception& e) {
-    log_severe("Caught exception: %s", e.what());
+    log(SEVERE, "Caught exception: %s", e.what());
     jint ret = env->ThrowNew(jniConstants->nativeExceptionClass, e.what());
     if (ret != 0) {
         fprintf(stderr, "JNI ThrowNew returned %d when rethrowing native exception: %s\n", ret, e.what());

--- a/src/file-events/cpp/jni_support.cpp
+++ b/src/file-events/cpp/jni_support.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <string>
 
 #include "jni_support.h"
@@ -42,7 +43,7 @@ JniThreadAttacher::JniThreadAttacher(JavaVM* jvm, const char* name, bool daemon)
         ? jvm->AttachCurrentThreadAsDaemon((void**) &env, (void*) &args)
         : jvm->AttachCurrentThread((void**) &env, (void*) &args);
     if (ret != JNI_OK) {
-        fprintf(stderr, "Failed to attach JNI to current thread: %d\n", ret);
+        cerr << "Failed to attach JNI to current thread: " << ret << endl;
         throw runtime_error(string("Failed to attach JNI to current thread: ") + to_string(ret));
     }
 }
@@ -50,6 +51,6 @@ JniThreadAttacher::JniThreadAttacher(JavaVM* jvm, const char* name, bool daemon)
 JniThreadAttacher::~JniThreadAttacher() {
     jint ret = jvm->DetachCurrentThread();
     if (ret != JNI_OK) {
-        fprintf(stderr, "Failed to detach JNI from current thread: %d\n", ret);
+        cerr << "Failed to detach JNI from current thread: " << ret << endl;
     }
 }

--- a/src/file-events/cpp/jni_support.cpp
+++ b/src/file-events/cpp/jni_support.cpp
@@ -1,4 +1,3 @@
-#include <exception>
 #include <string>
 
 #include "jni_support.h"
@@ -20,14 +19,6 @@ JniSupport::JniSupport(JavaVM* jvm)
 
 JniSupport::JniSupport(JNIEnv* env)
     : jvm(getJavaVm(env)) {
-}
-
-jclass JniSupport::findClass(const char* className) {
-    JNIEnv* env = getThreadEnv();
-    jclass localRef = env->FindClass(className);
-    jclass globalRef = reinterpret_cast<jclass>(env->NewGlobalRef(localRef));
-    env->DeleteLocalRef(localRef);
-    return globalRef;
 }
 
 JNIEnv* JniSupport::getThreadEnv() {

--- a/src/file-events/cpp/jni_support.cpp
+++ b/src/file-events/cpp/jni_support.cpp
@@ -22,6 +22,14 @@ JniSupport::JniSupport(JNIEnv* env)
     : jvm(getJavaVm(env)) {
 }
 
+jclass JniSupport::findClass(const char* className) {
+    JNIEnv* env = getThreadEnv();
+    jclass localRef = env->FindClass(className);
+    jclass globalRef = reinterpret_cast<jclass>(env->NewGlobalRef(localRef));
+    env->DeleteLocalRef(localRef);
+    return globalRef;
+}
+
 JNIEnv* JniSupport::getThreadEnv() {
     JNIEnv* env;
     jint ret = jvm->GetEnv((void**) &env, JNI_VERSION_1_6);

--- a/src/file-events/cpp/jni_support.cpp
+++ b/src/file-events/cpp/jni_support.cpp
@@ -1,0 +1,56 @@
+#include <exception>
+#include <string>
+
+#include "jni_support.h"
+
+using namespace std;
+
+JavaVM* getJavaVm(JNIEnv* env) {
+    JavaVM* jvm;
+    int jvmStatus = env->GetJavaVM(&jvm);
+    if (jvmStatus != 0) {
+        throw runtime_error(string("Could not get jvm instance: ") + to_string(jvmStatus));
+    }
+    return jvm;
+}
+
+JniSupport::JniSupport(JavaVM* jvm)
+    : jvm(jvm) {
+}
+
+JniSupport::JniSupport(JNIEnv* env)
+    : jvm(getJavaVm(env)) {
+}
+
+JNIEnv* JniSupport::getThreadEnv() {
+    JNIEnv* env;
+    jint ret = jvm->GetEnv((void**) &env, JNI_VERSION_1_6);
+    if (ret != JNI_OK) {
+        throw runtime_error(string("Failed to get JNI env for current thread: ") + to_string(ret));
+    }
+    return env;
+}
+
+JniThreadAttacher::JniThreadAttacher(JavaVM* jvm, const char* name, bool daemon)
+    : JniSupport(jvm) {
+    JNIEnv* env;
+    JavaVMAttachArgs args = {
+        JNI_VERSION_1_6,            // version
+        const_cast<char*>(name),    // thread name
+        NULL                        // thread group
+    };
+    jint ret = daemon
+        ? jvm->AttachCurrentThreadAsDaemon((void**) &env, (void*) &args)
+        : jvm->AttachCurrentThread((void**) &env, (void*) &args);
+    if (ret != JNI_OK) {
+        fprintf(stderr, "Failed to attach JNI to current thread: %d\n", ret);
+        throw runtime_error(string("Failed to attach JNI to current thread: ") + to_string(ret));
+    }
+}
+
+JniThreadAttacher::~JniThreadAttacher() {
+    jint ret = jvm->DetachCurrentThread();
+    if (ret != JNI_OK) {
+        fprintf(stderr, "Failed to detach JNI from current thread: %d\n", ret);
+    }
+}

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -72,7 +72,7 @@ Server::Server(JNIEnv* env, jobject watcherCallback)
 }
 
 void Server::terminate() {
-    log(FINE, "Terminating", NULL);
+    logToJava(FINE, "Terminating", NULL);
     terminated = true;
 }
 
@@ -146,7 +146,7 @@ void Server::handleEvents() {
             default:
                 // Handle events
                 JNIEnv* env = getThreadEnv();
-                log(FINE, "Processing %d bytes worth of events", bytesRead);
+                logToJava(FINE, "Processing %d bytes worth of events", bytesRead);
                 int index = 0;
                 int count = 0;
                 while (index < bytesRead) {
@@ -155,7 +155,7 @@ void Server::handleEvents() {
                     index += sizeof(struct inotify_event) + event->len;
                     count++;
                 }
-                log(FINE, "Processed %d events", count);
+                logToJava(FINE, "Processed %d events", count);
                 break;
         }
         available -= bytesRead;
@@ -171,7 +171,7 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
     const char* eventName = (event->len == 0)
         ? ""
         : event->name;
-    log(FINE, "Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
+    logToJava(FINE, "Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
     if (IS_ANY_SET(mask, IN_UNMOUNT)) {
         return;
     }
@@ -190,19 +190,19 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
 
     if (IS_SET(mask, IN_IGNORED)) {
         // Finished with watch point
-        log(FINE, "Finished watching '%s'", utf16ToUtf8String(path).c_str());
+        logToJava(FINE, "Finished watching '%s'", utf16ToUtf8String(path).c_str());
         watchPoint.status = FINISHED;
         return;
     }
 
     if (watchPoint.status != LISTENING) {
-        log(FINE, "Ignoring incoming events for %s as watch-point is not listening (status = %d)",
+        logToJava(FINE, "Ignoring incoming events for %s as watch-point is not listening (status = %d)",
             utf16ToUtf8String(path).c_str(), watchPoint.status);
         return;
     }
 
     if (terminated) {
-        log(FINE, "Ignoring incoming events for %s because server is terminating (status = %d)",
+        logToJava(FINE, "Ignoring incoming events for %s because server is terminating (status = %d)",
             utf16ToUtf8String(path).c_str(), watchPoint.status);
         return;
     }
@@ -260,7 +260,7 @@ void Server::registerPath(const u16string& path) {
 void Server::unregisterPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it == watchPoints.end() || it->second.status == FINISHED) {
-        log(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
     auto& watchPoint = it->second;

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -72,7 +72,7 @@ Server::Server(JNIEnv* env, jobject watcherCallback)
 }
 
 void Server::terminate() {
-    log_fine(getThreadEnv(), "Terminating", NULL);
+    log_fine("Terminating", NULL);
     terminated = true;
 }
 
@@ -83,7 +83,7 @@ Server::~Server() {
     }
 }
 
-void Server::runLoop(JNIEnv*, function<void(exception_ptr)> notifyStarted) {
+void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
     notifyStarted(nullptr);
 
     int forever = numeric_limits<int>::max();
@@ -146,7 +146,7 @@ void Server::handleEvents() {
             default:
                 // Handle events
                 JNIEnv* env = getThreadEnv();
-                log_fine(env, "Processing %d bytes worth of events", bytesRead);
+                log_fine("Processing %d bytes worth of events", bytesRead);
                 int index = 0;
                 int count = 0;
                 while (index < bytesRead) {
@@ -155,7 +155,7 @@ void Server::handleEvents() {
                     index += sizeof(struct inotify_event) + event->len;
                     count++;
                 }
-                log_fine(env, "Processed %d events", count);
+                log_fine("Processed %d events", count);
                 break;
         }
         available -= bytesRead;
@@ -171,7 +171,7 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
     const char* eventName = (event->len == 0)
         ? ""
         : event->name;
-    log_fine(env, "Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
+    log_fine("Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
     if (IS_ANY_SET(mask, IN_UNMOUNT)) {
         return;
     }
@@ -190,19 +190,19 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
 
     if (IS_SET(mask, IN_IGNORED)) {
         // Finished with watch point
-        log_fine(env, "Finished watching '%s'", utf16ToUtf8String(path).c_str());
+        log_fine("Finished watching '%s'", utf16ToUtf8String(path).c_str());
         watchPoint.status = FINISHED;
         return;
     }
 
     if (watchPoint.status != LISTENING) {
-        log_fine(env, "Ignoring incoming events for %s as watch-point is not listening (status = %d)",
+        log_fine("Ignoring incoming events for %s as watch-point is not listening (status = %d)",
             utf16ToUtf8String(path).c_str(), watchPoint.status);
         return;
     }
 
     if (terminated) {
-        log_fine(env, "Ignoring incoming events for %s because server is terminating (status = %d)",
+        log_fine("Ignoring incoming events for %s because server is terminating (status = %d)",
             utf16ToUtf8String(path).c_str(), watchPoint.status);
         return;
     }
@@ -260,7 +260,7 @@ void Server::registerPath(const u16string& path) {
 void Server::unregisterPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it == watchPoints.end() || it->second.status == FINISHED) {
-        log_fine(getThreadEnv(), "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        log_fine("Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
     auto& watchPoint = it->second;

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -72,7 +72,7 @@ Server::Server(JNIEnv* env, jobject watcherCallback)
 }
 
 void Server::terminate() {
-    log_fine("Terminating", NULL);
+    log(FINE, "Terminating", NULL);
     terminated = true;
 }
 
@@ -146,7 +146,7 @@ void Server::handleEvents() {
             default:
                 // Handle events
                 JNIEnv* env = getThreadEnv();
-                log_fine("Processing %d bytes worth of events", bytesRead);
+                log(FINE, "Processing %d bytes worth of events", bytesRead);
                 int index = 0;
                 int count = 0;
                 while (index < bytesRead) {
@@ -155,7 +155,7 @@ void Server::handleEvents() {
                     index += sizeof(struct inotify_event) + event->len;
                     count++;
                 }
-                log_fine("Processed %d events", count);
+                log(FINE, "Processed %d events", count);
                 break;
         }
         available -= bytesRead;
@@ -171,7 +171,7 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
     const char* eventName = (event->len == 0)
         ? ""
         : event->name;
-    log_fine("Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
+    log(FINE, "Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
     if (IS_ANY_SET(mask, IN_UNMOUNT)) {
         return;
     }
@@ -190,19 +190,19 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
 
     if (IS_SET(mask, IN_IGNORED)) {
         // Finished with watch point
-        log_fine("Finished watching '%s'", utf16ToUtf8String(path).c_str());
+        log(FINE, "Finished watching '%s'", utf16ToUtf8String(path).c_str());
         watchPoint.status = FINISHED;
         return;
     }
 
     if (watchPoint.status != LISTENING) {
-        log_fine("Ignoring incoming events for %s as watch-point is not listening (status = %d)",
+        log(FINE, "Ignoring incoming events for %s as watch-point is not listening (status = %d)",
             utf16ToUtf8String(path).c_str(), watchPoint.status);
         return;
     }
 
     if (terminated) {
-        log_fine("Ignoring incoming events for %s because server is terminating (status = %d)",
+        log(FINE, "Ignoring incoming events for %s because server is terminating (status = %d)",
             utf16ToUtf8String(path).c_str(), watchPoint.status);
         return;
     }
@@ -260,7 +260,7 @@ void Server::registerPath(const u16string& path) {
 void Server::unregisterPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it == watchPoints.end() || it->second.status == FINISHED) {
-        log_fine("Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        log(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
     auto& watchPoint = it->second;

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -1,7 +1,5 @@
 #include "logging.h"
 
-Logging* logging;
-
 Logging::Logging(JavaVM* jvm)
     : JniSupport(jvm)
     , clsLogger(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/NativeLogger")

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -13,6 +13,10 @@ Logging::Logging(JNIEnv* env, int level)
     , logMethod(env->GetStaticMethodID(clsLogger, "log", "(ILjava/lang/String;)V")) {
     printlog(LOG_CONFIG, "Initialized logging to level %d\n", level);
 }
+Logging::~Logging() {
+    JNIEnv* env = getThreadEnv();
+    env->DeleteGlobalRef(clsLogger);
+}
 
 void Logging::printlog(int level, const char* fmt, ...) {
     if (minimumLogLevel > level) {

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "logging.h"
 
 Logging::Logging(JavaVM* jvm)
@@ -26,7 +28,7 @@ void Logging::send(LogLevel level, const char* fmt, ...) {
 
     JNIEnv* env = getThreadEnv();
     if (env == NULL) {
-        fprintf(stderr, "%s\n", buffer);
+        cerr << buffer << endl;
     } else {
         jstring logString = env->NewStringUTF(buffer);
         env->CallStaticVoidMethod(clsLogger.get(), logMethod, level, logString);

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -18,7 +18,7 @@ Logging::~Logging() {
     env->DeleteGlobalRef(clsLogger);
 }
 
-inline bool Logging::enabled(LogLevel level) {
+bool Logging::enabled(LogLevel level) {
     return minimumLogLevel <= level;
 }
 

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -9,13 +9,9 @@ JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_NativeLogge
 Logging::Logging(JNIEnv* env, int level)
     : JniSupport(env)
     , minimumLogLevel(level)
-    , clsLogger(findClass("net/rubygrapefruit/platform/internal/jni/NativeLogger"))
-    , logMethod(env->GetStaticMethodID(clsLogger, "log", "(ILjava/lang/String;)V")) {
+    , clsLogger(env, "net/rubygrapefruit/platform/internal/jni/NativeLogger")
+    , logMethod(env->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V")) {
     send(LogLevel::CONFIG, "Initialized logging to level %d\n", level);
-}
-Logging::~Logging() {
-    JNIEnv* env = getThreadEnv();
-    env->DeleteGlobalRef(clsLogger);
 }
 
 bool Logging::enabled(LogLevel level) {
@@ -34,7 +30,7 @@ void Logging::send(LogLevel level, const char* fmt, ...) {
         fprintf(stderr, "%s\n", buffer);
     } else {
         jstring logString = env->NewStringUTF(buffer);
-        env->CallStaticVoidMethod(clsLogger, logMethod, level, logString);
+        env->CallStaticVoidMethod(clsLogger.get(), logMethod, level, logString);
         env->DeleteLocalRef(logString);
     }
 }

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -11,10 +11,10 @@ Logging::Logging(JNIEnv* env, int level)
     , minimumLogLevel(level)
     , clsLogger(findClass("net/rubygrapefruit/platform/internal/jni/NativeLogger"))
     , logMethod(env->GetStaticMethodID(clsLogger, "log", "(ILjava/lang/String;)V")) {
-    printlog(env, LOG_CONFIG, "Initialized logging to level %d\n", level);
+    printlog(LOG_CONFIG, "Initialized logging to level %d\n", level);
 }
 
-void Logging::printlog(JNIEnv* env, int level, const char* fmt, ...) {
+void Logging::printlog(int level, const char* fmt, ...) {
     if (minimumLogLevel > level) {
         return;
     }
@@ -25,6 +25,7 @@ void Logging::printlog(JNIEnv* env, int level, const char* fmt, ...) {
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
 
+    JNIEnv* env = getThreadEnv();
     if (env == NULL) {
         fprintf(stderr, "%s\n", buffer);
     } else {

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -11,18 +11,18 @@ Logging::Logging(JNIEnv* env, int level)
     , minimumLogLevel(level)
     , clsLogger(findClass("net/rubygrapefruit/platform/internal/jni/NativeLogger"))
     , logMethod(env->GetStaticMethodID(clsLogger, "log", "(ILjava/lang/String;)V")) {
-    printlog(LOG_CONFIG, "Initialized logging to level %d\n", level);
+    send(LogLevel::CONFIG, "Initialized logging to level %d\n", level);
 }
 Logging::~Logging() {
     JNIEnv* env = getThreadEnv();
     env->DeleteGlobalRef(clsLogger);
 }
 
-void Logging::printlog(int level, const char* fmt, ...) {
-    if (minimumLogLevel > level) {
-        return;
-    }
+inline bool Logging::enabled(LogLevel level) {
+    return minimumLogLevel <= level;
+}
 
+void Logging::send(LogLevel level, const char* fmt, ...) {
     char buffer[1024];
     va_list args;
     va_start(args, fmt);

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -10,11 +10,18 @@ Logging::Logging(JNIEnv* env, int level)
     : JniSupport(env)
     , minimumLogLevel(level)
     , clsLogger(env, "net/rubygrapefruit/platform/internal/jni/NativeLogger")
-    , logMethod(env->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V")) {
+    , logMethod(env->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V"))
+    , getLevelMethod(env->GetStaticMethodID(clsLogger.get(), "getLogLevel", "()I")) {
     send(LogLevel::CONFIG, "Initialized logging to level %d\n", level);
 }
 
 bool Logging::enabled(LogLevel level) {
+    auto current = chrono::steady_clock::now();
+    auto elapsed = chrono::duration_cast<chrono::milliseconds>(current - lastLevelCheck).count();
+    if (elapsed > LOG_LEVEL_CHECK_INTERVAL_IN_MS) {
+        minimumLogLevel = getThreadEnv()->CallStaticIntMethod(clsLogger.get(), getLevelMethod);
+        lastLevelCheck = current;
+    }
     return minimumLogLevel <= level;
 }
 

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -1,17 +1,20 @@
 #include "logging.h"
 
-int minimumLogLevel;
-jclass clsLogger;
-jmethodID logMethod;
+Logging* logging;
 
 JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_NativeLogger_initLogging(JNIEnv* env, jclass, jint level) {
-    minimumLogLevel = (int) level;
-    clsLogger = env->FindClass("net/rubygrapefruit/platform/internal/jni/NativeLogger");
-    logMethod = env->GetStaticMethodID(clsLogger, "log", "(ILjava/lang/String;)V");
+    logging = new Logging(env, (int) level);
+}
+
+Logging::Logging(JNIEnv* env, int level)
+    : JniSupport(env)
+    , minimumLogLevel(level)
+    , clsLogger(findClass("net/rubygrapefruit/platform/internal/jni/NativeLogger"))
+    , logMethod(env->GetStaticMethodID(clsLogger, "log", "(ILjava/lang/String;)V")) {
     printlog(env, LOG_CONFIG, "Initialized logging to level %d\n", level);
 }
 
-void printlog(JNIEnv* env, int level, const char* fmt, ...) {
+void Logging::printlog(JNIEnv* env, int level, const char* fmt, ...) {
     if (minimumLogLevel > level) {
         return;
     }

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -2,17 +2,11 @@
 
 Logging* logging;
 
-JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_NativeLogger_initLogging(JNIEnv* env, jclass, jint level) {
-    logging = new Logging(env, (int) level);
-}
-
-Logging::Logging(JNIEnv* env, int level)
-    : JniSupport(env)
-    , minimumLogLevel(level)
-    , clsLogger(env, "net/rubygrapefruit/platform/internal/jni/NativeLogger")
-    , logMethod(env->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V"))
-    , getLevelMethod(env->GetStaticMethodID(clsLogger.get(), "getLogLevel", "()I")) {
-    send(LogLevel::CONFIG, "Initialized logging to level %d\n", level);
+Logging::Logging(JavaVM* jvm)
+    : JniSupport(jvm)
+    , clsLogger(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/NativeLogger")
+    , logMethod(getThreadEnv()->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V"))
+    , getLevelMethod(getThreadEnv()->GetStaticMethodID(clsLogger.get(), "getLogLevel", "()I")) {
 }
 
 bool Logging::enabled(LogLevel level) {

--- a/src/file-events/cpp/logging.cpp
+++ b/src/file-events/cpp/logging.cpp
@@ -9,6 +9,10 @@ Logging::Logging(JavaVM* jvm)
     , getLevelMethod(getThreadEnv()->GetStaticMethodID(clsLogger.get(), "getLogLevel", "()I")) {
 }
 
+void Logging::invalidateLogLevelCache() {
+    lastLevelCheck = chrono::steady_clock::time_point();
+}
+
 bool Logging::enabled(LogLevel level) {
     auto current = chrono::steady_clock::now();
     auto elapsed = chrono::duration_cast<chrono::milliseconds>(current - lastLevelCheck).count();

--- a/src/file-events/cpp/services.cpp
+++ b/src/file-events/cpp/services.cpp
@@ -1,0 +1,18 @@
+#include "logging.h"
+#include "generic_fsnotifier.h"
+
+JniConstants* jniConstants;
+Logging* logging;
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM* jvm, void*) {
+    jniConstants = new JniConstants(jvm);
+    logging = new Logging(jvm);
+    return JNI_VERSION_1_6;
+}
+
+JNIEXPORT void JNICALL
+JNI_OnUnload(JavaVM*, void*) {
+    delete logging;
+    delete jniConstants;
+}

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -40,7 +40,7 @@ WatchPoint::WatchPoint(Server* server, const u16string& path)
 
 bool WatchPoint::cancel() {
     if (status == LISTENING) {
-        log(FINE, "Cancelling %s", utf16ToUtf8String(path).c_str());
+        logToJava(FINE, "Cancelling %s", utf16ToUtf8String(path).c_str());
         status = CANCELLED;
         bool cancelled = (bool) CancelIoEx(directoryHandle, &overlapped);
         if (!cancelled) {
@@ -48,7 +48,7 @@ bool WatchPoint::cancel() {
             DWORD lastError = GetLastError();
             if (lastError == ERROR_NOT_FOUND) {
                 // Do nothing, looks like this is a typical scenario
-                log(FINE, "Watch point already finished %s", utf16ToUtf8String(path).c_str());
+                logToJava(FINE, "Watch point already finished %s", utf16ToUtf8String(path).c_str());
             } else {
                 throw FileWatcherException("Couldn't cancel watch point", path, lastError);
             }
@@ -64,7 +64,7 @@ WatchPoint::~WatchPoint() {
             SleepEx(0, true);
         }
     } catch (const exception& ex) {
-        log(WARNING, "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
+        logToJava(WARNING, "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
     }
 }
 
@@ -108,17 +108,17 @@ ListenResult WatchPoint::listen() {
 
 void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
     if (errorCode == ERROR_OPERATION_ABORTED) {
-        log(FINE, "Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
+        logToJava(FINE, "Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
         BOOL ret = CloseHandle(directoryHandle);
         if (!ret) {
-            log(SEVERE, "Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
+            logToJava(SEVERE, "Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
         }
         status = FINISHED;
         return;
     }
 
     if (status != LISTENING) {
-        log(FINE, "Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
+        logToJava(FINE, "Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
             utf16ToUtf8String(path).c_str(), bytesTransferred, errorCode, status);
         return;
     }
@@ -140,14 +140,14 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         }
 
         if (terminated) {
-            log(FINE, "Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
+            logToJava(FINE, "Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
                 utf16ToUtf8String(path).c_str(), bytesTransferred, watchPoint->status);
             return;
         }
 
         if (bytesTransferred == 0) {
             // Got a buffer overflow => current changes lost => send INVALIDATE on root
-            log(INFO, "Detected overflow for %s", utf16ToUtf8String(path).c_str());
+            logToJava(INFO, "Detected overflow for %s", utf16ToUtf8String(path).c_str());
             reportChange(env, FILE_EVENT_INVALIDATE, path);
             watchPoint->status = FINISHED;
             return;
@@ -242,7 +242,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
         }
     }
 
-    // log(FINE, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
+    // logToJava(FINE, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
 
     jint type;
     if (info->Action == FILE_ACTION_ADDED || info->Action == FILE_ACTION_RENAMED_NEW_NAME) {
@@ -252,7 +252,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
     } else if (info->Action == FILE_ACTION_MODIFIED) {
         type = FILE_EVENT_MODIFIED;
     } else {
-        log(WARNING, "Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
+        logToJava(WARNING, "Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
         type = FILE_EVENT_UNKNOWN;
     }
 
@@ -290,7 +290,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
     }
 
     // We have received termination, cancel all watchers
-    log(FINE, "Finished with run loop, now cancelling remaining watch points", NULL);
+    logToJava(FINE, "Finished with run loop, now cancelling remaining watch points", NULL);
     int pendingWatchPoints = 0;
     for (auto& it : watchPoints) {
         auto& watchPoint = it.second;
@@ -301,7 +301,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
                         pendingWatchPoints++;
                     }
                 } catch (const exception& ex) {
-                    log(SEVERE, "%s", ex.what());
+                    logToJava(SEVERE, "%s", ex.what());
                 }
                 break;
             case CANCELLED:
@@ -314,7 +314,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
 
     // If there are any pending watchers, wait for them to finish
     if (pendingWatchPoints > 0) {
-        log(FINE, "Waiting for %d pending watch points to finish", pendingWatchPoints);
+        logToJava(FINE, "Waiting for %d pending watch points to finish", pendingWatchPoints);
         SleepEx(0, true);
     }
 
@@ -326,7 +326,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
             case FINISHED:
                 break;
             default:
-                log(WARNING, "Watch point %s did not finish before termination timeout (status = %d)",
+                logToJava(WARNING, "Watch point %s did not finish before termination timeout (status = %d)",
                     utf16ToUtf8String(watchPoint.path).c_str(), watchPoint.status);
                 break;
         }
@@ -361,7 +361,7 @@ void Server::unregisterPath(const u16string& path) {
     u16string longPath = path;
     convertToLongPathIfNeeded(longPath);
     if (watchPoints.erase(longPath) == 0) {
-        log(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
 }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -40,7 +40,7 @@ WatchPoint::WatchPoint(Server* server, const u16string& path)
 
 bool WatchPoint::cancel() {
     if (status == LISTENING) {
-        log_fine("Cancelling %s", utf16ToUtf8String(path).c_str());
+        log(FINE, "Cancelling %s", utf16ToUtf8String(path).c_str());
         status = CANCELLED;
         bool cancelled = (bool) CancelIoEx(directoryHandle, &overlapped);
         if (!cancelled) {
@@ -48,7 +48,7 @@ bool WatchPoint::cancel() {
             DWORD lastError = GetLastError();
             if (lastError == ERROR_NOT_FOUND) {
                 // Do nothing, looks like this is a typical scenario
-                log_fine("Watch point already finished %s", utf16ToUtf8String(path).c_str());
+                log(FINE, "Watch point already finished %s", utf16ToUtf8String(path).c_str());
             } else {
                 throw FileWatcherException("Couldn't cancel watch point", path, lastError);
             }
@@ -64,7 +64,7 @@ WatchPoint::~WatchPoint() {
             SleepEx(0, true);
         }
     } catch (const exception& ex) {
-        log_warning("Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
+        log(WARNING, "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
     }
 }
 
@@ -108,17 +108,17 @@ ListenResult WatchPoint::listen() {
 
 void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
     if (errorCode == ERROR_OPERATION_ABORTED) {
-        log_fine("Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
+        log(FINE, "Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
         BOOL ret = CloseHandle(directoryHandle);
         if (!ret) {
-            log_severe("Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
+            log(SEVERE, "Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
         }
         status = FINISHED;
         return;
     }
 
     if (status != LISTENING) {
-        log_fine("Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
+        log(FINE, "Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
             utf16ToUtf8String(path).c_str(), bytesTransferred, errorCode, status);
         return;
     }
@@ -140,14 +140,14 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         }
 
         if (terminated) {
-            log_fine("Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
+            log(FINE, "Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
                 utf16ToUtf8String(path).c_str(), bytesTransferred, watchPoint->status);
             return;
         }
 
         if (bytesTransferred == 0) {
             // Got a buffer overflow => current changes lost => send INVALIDATE on root
-            log_info("Detected overflow for %s", utf16ToUtf8String(path).c_str());
+            log(INFO, "Detected overflow for %s", utf16ToUtf8String(path).c_str());
             reportChange(env, FILE_EVENT_INVALIDATE, path);
             watchPoint->status = FINISHED;
             return;
@@ -242,7 +242,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
         }
     }
 
-    // log_fine("Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
+    // log(FINE, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
 
     jint type;
     if (info->Action == FILE_ACTION_ADDED || info->Action == FILE_ACTION_RENAMED_NEW_NAME) {
@@ -252,7 +252,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
     } else if (info->Action == FILE_ACTION_MODIFIED) {
         type = FILE_EVENT_MODIFIED;
     } else {
-        log_warning("Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
+        log(WARNING, "Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
         type = FILE_EVENT_UNKNOWN;
     }
 
@@ -290,7 +290,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
     }
 
     // We have received termination, cancel all watchers
-    log_fine("Finished with run loop, now cancelling remaining watch points", NULL);
+    log(FINE, "Finished with run loop, now cancelling remaining watch points", NULL);
     int pendingWatchPoints = 0;
     for (auto& it : watchPoints) {
         auto& watchPoint = it.second;
@@ -301,7 +301,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
                         pendingWatchPoints++;
                     }
                 } catch (const exception& ex) {
-                    log_severe("%s", ex.what());
+                    log(SEVERE, "%s", ex.what());
                 }
                 break;
             case CANCELLED:
@@ -314,7 +314,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
 
     // If there are any pending watchers, wait for them to finish
     if (pendingWatchPoints > 0) {
-        log_fine("Waiting for %d pending watch points to finish", pendingWatchPoints);
+        log(FINE, "Waiting for %d pending watch points to finish", pendingWatchPoints);
         SleepEx(0, true);
     }
 
@@ -326,7 +326,7 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
             case FINISHED:
                 break;
             default:
-                log_warning("Watch point %s did not finish before termination timeout (status = %d)",
+                log(WARNING, "Watch point %s did not finish before termination timeout (status = %d)",
                     utf16ToUtf8String(watchPoint.path).c_str(), watchPoint.status);
                 break;
         }
@@ -361,7 +361,7 @@ void Server::unregisterPath(const u16string& path) {
     u16string longPath = path;
     convertToLongPathIfNeeded(longPath);
     if (watchPoints.erase(longPath) == 0) {
-        log_fine("Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        log(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
 }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -40,7 +40,7 @@ WatchPoint::WatchPoint(Server* server, const u16string& path)
 
 bool WatchPoint::cancel() {
     if (status == LISTENING) {
-        log_fine(server->getThreadEnv(), "Cancelling %s", utf16ToUtf8String(path).c_str());
+        log_fine("Cancelling %s", utf16ToUtf8String(path).c_str());
         status = CANCELLED;
         bool cancelled = (bool) CancelIoEx(directoryHandle, &overlapped);
         if (!cancelled) {
@@ -48,7 +48,7 @@ bool WatchPoint::cancel() {
             DWORD lastError = GetLastError();
             if (lastError == ERROR_NOT_FOUND) {
                 // Do nothing, looks like this is a typical scenario
-                log_fine(server->getThreadEnv(), "Watch point already finished %s", utf16ToUtf8String(path).c_str());
+                log_fine("Watch point already finished %s", utf16ToUtf8String(path).c_str());
             } else {
                 throw FileWatcherException("Couldn't cancel watch point", path, lastError);
             }
@@ -64,7 +64,7 @@ WatchPoint::~WatchPoint() {
             SleepEx(0, true);
         }
     } catch (const exception& ex) {
-        log_warning(server->getThreadEnv(), "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
+        log_warning("Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
     }
 }
 
@@ -108,17 +108,17 @@ ListenResult WatchPoint::listen() {
 
 void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
     if (errorCode == ERROR_OPERATION_ABORTED) {
-        log_fine(server->getThreadEnv(), "Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
+        log_fine("Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
         BOOL ret = CloseHandle(directoryHandle);
         if (!ret) {
-            log_severe(server->getThreadEnv(), "Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
+            log_severe("Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
         }
         status = FINISHED;
         return;
     }
 
     if (status != LISTENING) {
-        log_fine(server->getThreadEnv(), "Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
+        log_fine("Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
             utf16ToUtf8String(path).c_str(), bytesTransferred, errorCode, status);
         return;
     }
@@ -140,14 +140,14 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         }
 
         if (terminated) {
-            log_fine(env, "Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
+            log_fine("Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
                 utf16ToUtf8String(path).c_str(), bytesTransferred, watchPoint->status);
             return;
         }
 
         if (bytesTransferred == 0) {
             // Got a buffer overflow => current changes lost => send INVALIDATE on root
-            log_info(env, "Detected overflow for %s", utf16ToUtf8String(path).c_str());
+            log_info("Detected overflow for %s", utf16ToUtf8String(path).c_str());
             reportChange(env, FILE_EVENT_INVALIDATE, path);
             watchPoint->status = FINISHED;
             return;
@@ -242,7 +242,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
         }
     }
 
-    // log_fine(env, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
+    // log_fine("Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
 
     jint type;
     if (info->Action == FILE_ACTION_ADDED || info->Action == FILE_ACTION_RENAMED_NEW_NAME) {
@@ -252,7 +252,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
     } else if (info->Action == FILE_ACTION_MODIFIED) {
         type = FILE_EVENT_MODIFIED;
     } else {
-        log_warning(env, "Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
+        log_warning("Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
         type = FILE_EVENT_UNKNOWN;
     }
 
@@ -271,7 +271,6 @@ Server::Server(JNIEnv* env, jobject watcherCallback)
 }
 
 void Server::terminate() {
-    log_fine(getThreadEnv(), "Terminating", NULL);
     terminated = true;
 }
 
@@ -283,7 +282,7 @@ Server::~Server() {
     }
 }
 
-void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
+void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
     notifyStarted(nullptr);
 
     while (!terminated) {
@@ -291,7 +290,7 @@ void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
     }
 
     // We have received termination, cancel all watchers
-    log_fine(env, "Finished with run loop, now cancelling remaining watch points", NULL);
+    log_fine("Finished with run loop, now cancelling remaining watch points", NULL);
     int pendingWatchPoints = 0;
     for (auto& it : watchPoints) {
         auto& watchPoint = it.second;
@@ -302,7 +301,7 @@ void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
                         pendingWatchPoints++;
                     }
                 } catch (const exception& ex) {
-                    log_severe(env, "%s", ex.what());
+                    log_severe("%s", ex.what());
                 }
                 break;
             case CANCELLED:
@@ -315,7 +314,7 @@ void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
 
     // If there are any pending watchers, wait for them to finish
     if (pendingWatchPoints > 0) {
-        log_fine(env, "Waiting for %d pending watch points to finish", pendingWatchPoints);
+        log_fine("Waiting for %d pending watch points to finish", pendingWatchPoints);
         SleepEx(0, true);
     }
 
@@ -327,7 +326,7 @@ void Server::runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) {
             case FINISHED:
                 break;
             default:
-                log_warning(env, "Watch point %s did not finish before termination timeout (status = %d)",
+                log_warning("Watch point %s did not finish before termination timeout (status = %d)",
                     utf16ToUtf8String(watchPoint.path).c_str(), watchPoint.status);
                 break;
         }
@@ -362,7 +361,7 @@ void Server::unregisterPath(const u16string& path) {
     u16string longPath = path;
     convertToLongPathIfNeeded(longPath);
     if (watchPoints.erase(longPath) == 0) {
-        log_fine(getThreadEnv(), "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        log_fine("Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
 }

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -45,7 +45,7 @@ public:
         const FSEventStreamEventFlags eventFlags[]);
 
 protected:
-    void runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) override;
+    void runLoop(function<void(exception_ptr)> notifyStarted) override;
     void processCommandsOnThread() override;
 
 private:

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -120,7 +120,7 @@ protected:
     void reportError(JNIEnv* env, const exception& ex);
 
     void startThread();
-    virtual void runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) = 0;
+    virtual void runLoop(function<void(exception_ptr)> notifyStarted) = 0;
     virtual void processCommandsOnThread() = 0;
 
     thread watcherThread;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -183,9 +183,6 @@ public:
     const jclass nativeExceptionClass;
     const jclass classClass;
     const jclass nativeFileWatcherClass;
-
-private:
-    const jclass findClass(const char* className);
 };
 
 extern JniConstants* jniConstants;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <thread>
 
+#include "jni_support.h"
 #include "logging.h"
 #include "net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_NativeFileWatcher.h"
 
@@ -59,8 +60,8 @@ class AbstractServer;
 
 class Command {
 public:
-    Command() {};
-    virtual ~Command() {};
+    Command(){};
+    virtual ~Command(){};
 
     void execute(AbstractServer* server) {
         try {
@@ -77,7 +78,7 @@ public:
     exception_ptr failure;
 };
 
-class AbstractServer {
+class AbstractServer : public JniSupport {
 public:
     AbstractServer(JNIEnv* env, jobject watcherCallback);
     virtual ~AbstractServer();
@@ -114,8 +115,6 @@ public:
      */
     virtual void terminate() = 0;
 
-    JNIEnv* getThreadEnv();
-
 protected:
     void reportChange(JNIEnv* env, int type, const u16string& path);
     void reportError(JNIEnv* env, const exception& ex);
@@ -139,8 +138,6 @@ private:
     jobject watcherCallback;
     jmethodID watcherCallbackMethod;
     jmethodID watcherReportErrorMethod;
-
-    JavaVM* jvm;
 };
 
 class RegisterPathCommand : public Command {
@@ -178,13 +175,17 @@ public:
     }
 };
 
-struct JniConstants {
-    JniConstants(JNIEnv* env);
-    void unload(JNIEnv* env);
+class JniConstants : public JniSupport {
+public:
+    JniConstants(JavaVM* jvm);
+    ~JniConstants();
 
     const jclass nativeExceptionClass;
     const jclass classClass;
     const jclass nativeFileWatcherClass;
+
+private:
+    const jclass findClass(const char* className);
 };
 
 extern JniConstants* jniConstants;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -135,7 +135,7 @@ private:
     mutex mtxCommands;
     deque<shared_ptr<Command>> commands;
 
-    jobject watcherCallback;
+    JniGlobalRef<jobject> watcherCallback;
     jmethodID watcherCallbackMethod;
     jmethodID watcherReportErrorMethod;
 };
@@ -178,11 +178,10 @@ public:
 class JniConstants : public JniSupport {
 public:
     JniConstants(JavaVM* jvm);
-    ~JniConstants();
 
-    const jclass nativeExceptionClass;
-    const jclass classClass;
-    const jclass nativeFileWatcherClass;
+    const JClass nativeExceptionClass;
+    const JClass classClass;
+    const JClass nativeFileWatcherClass;
 };
 
 extern JniConstants* jniConstants;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -60,8 +60,8 @@ class AbstractServer;
 
 class Command {
 public:
-    Command(){};
-    virtual ~Command(){};
+    Command() {};
+    virtual ~Command() {};
 
     void execute(AbstractServer* server) {
         try {

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -3,6 +3,7 @@
 #include <condition_variable>
 #include <exception>
 #include <functional>
+#include <iostream>
 #include <list>
 #include <memory>
 #include <mutex>

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -13,6 +13,7 @@
 
 #include "jni_support.h"
 #include "logging.h"
+#include "net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions.h"
 #include "net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_NativeFileWatcher.h"
 
 using namespace std;

--- a/src/file-events/headers/jni_support.h
+++ b/src/file-events/headers/jni_support.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jni.h>
+#include <stdexcept>
 
 /**
  * Support for using JNI in a multi-threaded environment.

--- a/src/file-events/headers/jni_support.h
+++ b/src/file-events/headers/jni_support.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <jni.h>
+
+/**
+ * Support for using JNI in a multi-threaded environment.
+ */
+class JniSupport {
+public:
+    JniSupport(JavaVM* jvm);
+    JniSupport(JNIEnv* env);
+
+protected:
+    JNIEnv* getThreadEnv();
+
+protected:
+    JavaVM* jvm;
+};
+
+/**
+ * Attach a native thread to JNI.
+ */
+class JniThreadAttacher : public JniSupport {
+public:
+    JniThreadAttacher(JavaVM* jvm, const char* name, bool daemon);
+    ~JniThreadAttacher();
+};

--- a/src/file-events/headers/jni_support.h
+++ b/src/file-events/headers/jni_support.h
@@ -3,6 +3,11 @@
 #include <jni.h>
 #include <stdexcept>
 
+using namespace std;
+
+template <typename T>
+class JniGlobalRef;
+
 /**
  * Support for using JNI in a multi-threaded environment.
  */
@@ -12,11 +17,40 @@ public:
     JniSupport(JNIEnv* env);
 
 protected:
-    jclass findClass(const char* className);
+    const JniGlobalRef<jclass>& findClass(const char* className);
     JNIEnv* getThreadEnv();
 
 protected:
     JavaVM* jvm;
+};
+
+template <typename T>
+class JniGlobalRef : public JniSupport {
+public:
+    JniGlobalRef(JNIEnv* env, T object)
+        : JniSupport(env)
+        , ref(reinterpret_cast<T>(env->NewGlobalRef(object))) {
+        if (ref == nullptr) {
+            throw runtime_error("Failed to create global JNI reference");
+        }
+    }
+    ~JniGlobalRef() {
+        getThreadEnv()->DeleteGlobalRef(ref);
+    }
+
+    T get() const {
+        return ref;
+    }
+
+private:
+    const T ref;
+};
+
+class JClass : public JniGlobalRef<jclass> {
+public:
+    JClass(JNIEnv* env, const char* className)
+        : JniGlobalRef(env, env->FindClass(className)) {
+    }
 };
 
 /**

--- a/src/file-events/headers/jni_support.h
+++ b/src/file-events/headers/jni_support.h
@@ -11,6 +11,7 @@ public:
     JniSupport(JNIEnv* env);
 
 protected:
+    jclass findClass(const char* className);
     JNIEnv* getThreadEnv();
 
 protected:

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -58,7 +58,7 @@ public:
     void unregisterPath(const u16string& path) override;
 
 protected:
-    void runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) override;
+    void runLoop(function<void(exception_ptr)> notifyStarted) override;
     void processCommandsOnThread() override;
     void terminate() override;
 

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -17,7 +17,7 @@ class Logging : public JniSupport {
 public:
     Logging(JNIEnv* env, int level);
 
-    void printlog(JNIEnv* env, int level, const char* message, ...);
+    void printlog(int level, const char* message, ...);
 
 private:
     int minimumLogLevel;
@@ -27,10 +27,10 @@ private:
 
 extern Logging* logging;
 
-#define log_finest(env, message, ...) (logging->printlog(env, LOG_FINEST, message, __VA_ARGS__))
-#define log_finer(env, message, ...) (logging->printlog(env, LOG_FINER, message, __VA_ARGS__)
-#define log_fine(env, message, ...) (logging->printlog(env, LOG_FINE, message, __VA_ARGS__))
-#define log_config(env, message, ...) (logging->printlog(env, LOG_CONFIG, message, __VA_ARGS__))
-#define log_info(env, message, ...) (logging->printlog(env, LOG_INFO, message, __VA_ARGS__))
-#define log_warning(env, message, ...) (logging->printlog(env, LOG_WARNING, message, __VA_ARGS__))
-#define log_severe(env, message, ...) (logging->printlog(env, LOG_SEVERE, message, __VA_ARGS__))
+#define log_finest(message, ...) (logging->printlog(LOG_FINEST, message, __VA_ARGS__))
+#define log_finer(message, ...) (logging->printlog(LOG_FINER, message, __VA_ARGS__)
+#define log_fine(message, ...) (logging->printlog(LOG_FINE, message, __VA_ARGS__))
+#define log_config(message, ...) (logging->printlog(LOG_CONFIG, message, __VA_ARGS__))
+#define log_info(message, ...) (logging->printlog(LOG_INFO, message, __VA_ARGS__))
+#define log_warning(message, ...) (logging->printlog(LOG_WARNING, message, __VA_ARGS__))
+#define log_severe(message, ...) (logging->printlog(LOG_SEVERE, message, __VA_ARGS__))

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -21,6 +21,7 @@ class Logging : public JniSupport {
 public:
     Logging(JavaVM* jvm);
 
+    void invalidateLogLevelCache();
     bool enabled(LogLevel level);
     void send(LogLevel level, const char* fmt, ...);
 

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "net_rubygrapefruit_platform_internal_jni_NativeLogger.h"
 #include <jni.h>
+
+#include "jni_support.h"
+#include "net_rubygrapefruit_platform_internal_jni_NativeLogger.h"
 
 #define LOG_FINEST 0
 #define LOG_FINER 1
@@ -11,12 +13,24 @@
 #define LOG_WARNING 5
 #define LOG_SEVERE 6
 
-#define log_finest(env, message, ...) printlog(env, LOG_FINEST, message, __VA_ARGS__)
-#define log_finer(env, message, ...) printlog(env, LOG_FINER, message, __VA_ARGS__)
-#define log_fine(env, message, ...) printlog(env, LOG_FINE, message, __VA_ARGS__)
-#define log_config(env, message, ...) printlog(env, LOG_CONFIG, message, __VA_ARGS__)
-#define log_info(env, message, ...) printlog(env, LOG_INFO, message, __VA_ARGS__)
-#define log_warning(env, message, ...) printlog(env, LOG_WARNING, message, __VA_ARGS__)
-#define log_severe(env, message, ...) printlog(env, LOG_SEVERE, message, __VA_ARGS__)
+class Logging : public JniSupport {
+public:
+    Logging(JNIEnv* env, int level);
 
-void printlog(JNIEnv* env, int level, const char* message, ...);
+    void printlog(JNIEnv* env, int level, const char* message, ...);
+
+private:
+    int minimumLogLevel;
+    const jclass clsLogger;
+    const jmethodID logMethod;
+};
+
+extern Logging* logging;
+
+#define log_finest(env, message, ...) (logging->printlog(env, LOG_FINEST, message, __VA_ARGS__))
+#define log_finer(env, message, ...) (logging->printlog(env, LOG_FINER, message, __VA_ARGS__)
+#define log_fine(env, message, ...) (logging->printlog(env, LOG_FINE, message, __VA_ARGS__))
+#define log_config(env, message, ...) (logging->printlog(env, LOG_CONFIG, message, __VA_ARGS__))
+#define log_info(env, message, ...) (logging->printlog(env, LOG_INFO, message, __VA_ARGS__))
+#define log_warning(env, message, ...) (logging->printlog(env, LOG_WARNING, message, __VA_ARGS__))
+#define log_severe(env, message, ...) (logging->printlog(env, LOG_SEVERE, message, __VA_ARGS__))

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -25,7 +25,7 @@ public:
 
 private:
     int minimumLogLevel;
-    const jclass clsLogger;
+    const JClass clsLogger;
     const jmethodID logMethod;
 };
 

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -4,7 +4,6 @@
 #include <jni.h>
 
 #include "jni_support.h"
-#include "net_rubygrapefruit_platform_internal_jni_NativeLogger.h"
 
 #define LOG_LEVEL_CHECK_INTERVAL_IN_MS 1000
 
@@ -20,8 +19,7 @@ enum LogLevel : int {
 
 class Logging : public JniSupport {
 public:
-    Logging(JNIEnv* env, int level);
-    ~Logging();
+    Logging(JavaVM* jvm);
 
     bool enabled(LogLevel level);
     void send(LogLevel level, const char* fmt, ...);

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <chrono>
 #include <jni.h>
 
 #include "jni_support.h"
 #include "net_rubygrapefruit_platform_internal_jni_NativeLogger.h"
+
+#define LOG_LEVEL_CHECK_INTERVAL_IN_MS 1000
 
 enum LogLevel : int {
     FINEST = 0,
@@ -27,6 +30,8 @@ private:
     int minimumLogLevel;
     const JClass clsLogger;
     const jmethodID logMethod;
+    const jmethodID getLevelMethod;
+    chrono::time_point<chrono::steady_clock> lastLevelCheck;
 };
 
 extern Logging* logging;

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -5,20 +5,23 @@
 #include "jni_support.h"
 #include "net_rubygrapefruit_platform_internal_jni_NativeLogger.h"
 
-#define LOG_FINEST 0
-#define LOG_FINER 1
-#define LOG_FINE 2
-#define LOG_CONFIG 3
-#define LOG_INFO 4
-#define LOG_WARNING 5
-#define LOG_SEVERE 6
+enum LogLevel : int {
+    FINEST = 0,
+    FINER = 1,
+    FINE = 2,
+    CONFIG = 3,
+    INFO = 4,
+    WARNING = 5,
+    SEVERE = 6
+};
 
 class Logging : public JniSupport {
 public:
     Logging(JNIEnv* env, int level);
     ~Logging();
 
-    void printlog(int level, const char* message, ...);
+    bool enabled(LogLevel level);
+    void send(LogLevel level, const char* fmt, ...);
 
 private:
     int minimumLogLevel;
@@ -28,10 +31,4 @@ private:
 
 extern Logging* logging;
 
-#define log_finest(message, ...) (logging->printlog(LOG_FINEST, message, __VA_ARGS__))
-#define log_finer(message, ...) (logging->printlog(LOG_FINER, message, __VA_ARGS__)
-#define log_fine(message, ...) (logging->printlog(LOG_FINE, message, __VA_ARGS__))
-#define log_config(message, ...) (logging->printlog(LOG_CONFIG, message, __VA_ARGS__))
-#define log_info(message, ...) (logging->printlog(LOG_INFO, message, __VA_ARGS__))
-#define log_warning(message, ...) (logging->printlog(LOG_WARNING, message, __VA_ARGS__))
-#define log_severe(message, ...) (logging->printlog(LOG_SEVERE, message, __VA_ARGS__))
+#define log(level, message, ...) (logging->enabled(level) ? logging->send(level, message, __VA_ARGS__) : ((void) NULL))

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -16,6 +16,7 @@
 class Logging : public JniSupport {
 public:
     Logging(JNIEnv* env, int level);
+    ~Logging();
 
     void printlog(int level, const char* message, ...);
 

--- a/src/file-events/headers/logging.h
+++ b/src/file-events/headers/logging.h
@@ -34,4 +34,4 @@ private:
 
 extern Logging* logging;
 
-#define log(level, message, ...) (logging->enabled(level) ? logging->send(level, message, __VA_ARGS__) : ((void) NULL))
+#define logToJava(level, message, ...) (logging->enabled(level) ? logging->send(level, message, __VA_ARGS__) : ((void) NULL))

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -71,7 +71,7 @@ public:
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
 
 protected:
-    void runLoop(JNIEnv* env, function<void(exception_ptr)> notifyStarted) override;
+    void runLoop(function<void(exception_ptr)> notifyStarted) override;
     void processCommandsOnThread() override;
 
 private:

--- a/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -28,9 +28,8 @@ import net.rubygrapefruit.platform.file.Files;
 import net.rubygrapefruit.platform.file.PosixFiles;
 import net.rubygrapefruit.platform.file.WindowsFiles;
 import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions;
-import net.rubygrapefruit.platform.internal.jni.NativeLogger;
-import net.rubygrapefruit.platform.internal.jni.NativeVersion;
 import net.rubygrapefruit.platform.internal.jni.LinuxFileEventFunctions;
+import net.rubygrapefruit.platform.internal.jni.NativeVersion;
 import net.rubygrapefruit.platform.internal.jni.OsxFileEventFunctions;
 import net.rubygrapefruit.platform.internal.jni.PosixTypeFunctions;
 import net.rubygrapefruit.platform.internal.jni.TerminfoFunctions;
@@ -142,7 +141,6 @@ public abstract class Platform {
 
     protected void initFileEventFunctions(NativeLibraryLoader nativeLibraryLoader) {
         nativeLibraryLoader.load(getFileEventsLibraryName(), getLibraryVariants());
-        NativeLogger.initLogging(AbstractFileEventFunctions.class);
         String nativeVersion = AbstractFileEventFunctions.getVersion();
         if (!nativeVersion.equals(NativeVersion.VERSION)) {
             throw new NativeException(String.format(

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -10,6 +10,12 @@ import java.io.File;
 public class AbstractFileEventFunctions implements NativeIntegration {
     public static native String getVersion();
 
+    /**
+     * Forces the native backend to drop the cached JUL log level and thus
+     * re-query it the next time it tries to log something to the Java side.
+     */
+    public native void invalidateLogLevelCache();
+
     protected static class NativeFileWatcherCallback {
         private final FileWatcherCallback delegate;
 

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/NativeLogger.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/NativeLogger.java
@@ -63,4 +63,16 @@ public class NativeLogger {
     public static void log(int level, String message) {
         LOGGER.log(LogLevel.values()[level].getLevel(), message);
     }
+
+    // Used from native
+    @SuppressWarnings("unused")
+    public static int getLogLevel() {
+        Level level = LOGGER.getLevel();
+        for (LogLevel logLevel : LogLevel.values()) {
+            if (logLevel.getLevel().equals(level)) {
+                return logLevel.ordinal();
+            }
+        }
+        throw new AssertionError();
+    }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -19,8 +19,8 @@ package net.rubygrapefruit.platform.file
 import groovy.transform.EqualsAndHashCode
 import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.internal.Platform
-import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions
 import net.rubygrapefruit.platform.internal.jni.LinuxFileEventFunctions
+import net.rubygrapefruit.platform.internal.jni.NativeLogger
 import net.rubygrapefruit.platform.internal.jni.OsxFileEventFunctions
 import net.rubygrapefruit.platform.internal.jni.WindowsFileEventFunctions
 import net.rubygrapefruit.platform.testfixture.JulLogging
@@ -47,7 +47,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
     @Rule
     TestName testName
     @Rule
-    JulLogging logging = new JulLogging(AbstractFileEventFunctions, FINE)
+    JulLogging logging = new JulLogging(NativeLogger, FINE)
 
     def callback = new TestCallback()
     File testDir

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -17,8 +17,10 @@
 package net.rubygrapefruit.platform.file
 
 import groovy.transform.EqualsAndHashCode
+import groovy.transform.Memoized
 import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.internal.Platform
+import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions
 import net.rubygrapefruit.platform.internal.jni.LinuxFileEventFunctions
 import net.rubygrapefruit.platform.internal.jni.NativeLogger
 import net.rubygrapefruit.platform.internal.jni.OsxFileEventFunctions
@@ -82,11 +84,17 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         MAC_OS(){
             private static final int LATENCY_IN_MILLIS = 0
 
+            @Memoized
+            @Override
+            OsxFileEventFunctions getService() {
+                Native.get(OsxFileEventFunctions)
+            }
+
             @Override
             FileWatcher startNewWatcher(FileWatcherCallback callback) {
                 // Avoid setup operations to be reported
                 waitForChangeEventLatency()
-                Native.get(OsxFileEventFunctions.class).startWatcher(
+                service.startWatcher(
                     LATENCY_IN_MILLIS, TimeUnit.MILLISECONDS,
                     callback
                 )
@@ -98,11 +106,17 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
         },
         LINUX(){
+            @Memoized
+            @Override
+            LinuxFileEventFunctions getService() {
+                Native.get(LinuxFileEventFunctions)
+            }
+
             @Override
             FileWatcher startNewWatcher(FileWatcherCallback callback) {
                 // Avoid setup operations to be reported
                 waitForChangeEventLatency()
-                Native.get(LinuxFileEventFunctions.class).startWatcher(callback)
+                service.startWatcher(callback)
             }
 
             @Override
@@ -111,9 +125,15 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
         },
         WINDOWS(){
+            @Memoized
+            @Override
+            WindowsFileEventFunctions getService() {
+                Native.get(WindowsFileEventFunctions)
+            }
+
             @Override
             FileWatcher startNewWatcher(FileWatcherCallback callback) {
-                Native.get(WindowsFileEventFunctions.class).startWatcher(callback)
+                service.startWatcher(callback)
             }
 
             @Override
@@ -122,6 +142,11 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
         },
         UNSUPPORTED() {
+            @Override
+            AbstractFileEventFunctions getService() {
+                throw new UnsupportedOperationException()
+            }
+
             @Override
             FileWatcher startNewWatcher(FileWatcherCallback callback) {
                 throw new UnsupportedOperationException()
@@ -144,6 +169,8 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
                 return UNSUPPORTED
             }
         }
+
+        abstract AbstractFileEventFunctions getService();
 
         abstract FileWatcher startNewWatcher(FileWatcherCallback callback)
 
@@ -209,6 +236,10 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         String toString() {
             return "${mandatory ? "" : "optional "}$type $file"
         }
+    }
+
+    protected AbstractFileEventFunctions getService() {
+        watcherFixture.service
     }
 
     protected FileWatcher startNewWatcher(FileWatcherCallback callback) {

--- a/src/test/groovy/net/rubygrapefruit/platform/testfixture/JulLogging.java
+++ b/src/test/groovy/net/rubygrapefruit/platform/testfixture/JulLogging.java
@@ -59,6 +59,10 @@ public class JulLogging extends TestWatcher {
         return recorder.messages;
     }
 
+    public void clear() {
+        recorder.messages.clear();
+    }
+
     private static class RecordingHandler extends Handler {
         private final Map<String, Level> messages = new LinkedHashMap<String, Level>();
 


### PR DESCRIPTION
A number of improvements around logging:

- no initialization of the logging required, instead we initialize in `JNI_OnLoad()`
- log level is queried from the native side, and cached for 1 second
- no need to pass `JNIEnv*` to logging anymore
- `log_fine()` etc. is replaced with `log(FINE, ...)`

- added `jni_support.cpp` with all the JNI stuff
- assed `JniSupport` for types that need to work with JNI
- added `JniGlobalRef` RAII
