### PR TITLE
Do not block on unregistering a watch point on Linux

### DIFF
--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -265,7 +265,7 @@ void Server::unregisterPath(const u16string& path) {
     }
     auto& watchPoint = it->second;
     if (watchPoint.cancel()) {
-        processQueues(CLOSE_TIMEOUT_IN_MS);
+        processQueues(0);
     }
     if (watchPoint.status != FINISHED) {
         throw FileWatcherException("Could not cancel watch point %s", path);

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -12,9 +12,6 @@
 
 using namespace std;
 
-// TODO Make this parametrizable perhaps
-#define CLOSE_TIMEOUT_IN_MS 1000
-
 class Server;
 
 struct Inotify {


### PR DESCRIPTION
A timeout doesn't seem to be necessary.