### PR TITLE
Wait only five seconds for thread operations

### DIFF
--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <condition_variable>
 #include <exception>
 #include <functional>
@@ -27,6 +28,8 @@ using namespace std;
 
 #define IS_SET(flags, flag) (((flags) & (flag)) == (flag))
 #define IS_ANY_SET(flags, mask) (((flags) & (mask)) != 0)
+
+#define THREAD_TIMEOUT (chrono::seconds(1))
 
 struct FileWatcherException : public runtime_error {
 public:

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -29,7 +29,7 @@ using namespace std;
 #define IS_SET(flags, flag) (((flags) & (flag)) == (flag))
 #define IS_ANY_SET(flags, mask) (((flags) & (mask)) != 0)
 
-#define THREAD_TIMEOUT (chrono::seconds(1))
+#define THREAD_TIMEOUT (chrono::seconds(5))
 
 struct FileWatcherException : public runtime_error {
 public:


### PR DESCRIPTION
We shouldn't wait forever for the background thread to start or for commands to execute.