### PR TITLE
Increase build timeout to 15 minutes

### DIFF
--- a/.teamcity/NativePlatformBuild.kt
+++ b/.teamcity/NativePlatformBuild.kt
@@ -45,7 +45,7 @@ open class NativePlatformBuild(agent: Agent, init: BuildType.() -> Unit = {}) : 
 
     failureConditions {
         testFailure = false
-        executionTimeoutMin = 5
+        executionTimeoutMin = 15
     }
 
     artifactRules = """


### PR DESCRIPTION
Sometimes Teamcity seems to hang on the builds. Let's see
if increasing the build timeout helps.