### PR TITLE
Add a test for hierarchical watchers deleting a hierarchy

### DIFF
--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -618,14 +618,14 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
             : Platform.current().windows
             ? [event(MODIFIED, removedFile), event(REMOVED, removedFile, false), event(REMOVED, watchedDir)]
             : [event(REMOVED, removedFile), event(REMOVED, watchedDir)]
-        def directoryDeleted = removedDir.deleteDir()
+        def directoryRemoved = removedDir.deleteDir()
 
         then:
         expectedChanges.await()
-        directoryDeleted == canDeleteDirectory
+        directoryRemoved == expectDirectoryRemoved
 
         where:
-        ancestry                            | removedDirectory             | canDeleteDirectory
+        ancestry                            | removedDirectory             | expectDirectoryRemoved
         "watched directory"                 | { it }                       | true
         "parent of watched directory"       | { it.parentFile }            | !OperatingSystem.current.windows
         "grand-parent of watched directory" | { it.parentFile.parentFile } | !OperatingSystem.current.windows

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -24,6 +24,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Unroll
 import spock.util.concurrent.AsyncConditions
+import spock.util.environment.OperatingSystem
 
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -617,16 +618,17 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
             : Platform.current().windows
             ? [event(MODIFIED, removedFile), event(REMOVED, removedFile, false), event(REMOVED, watchedDir)]
             : [event(REMOVED, removedFile), event(REMOVED, watchedDir)]
-        assert removedDir.deleteDir()
+        def directoryDeleted = removedDir.deleteDir()
 
         then:
         expectedChanges.await()
+        directoryDeleted == canDeleteDirectory
 
         where:
-        ancestry                            | removedDirectory
-        "watched directory"                 | { it }
-        "parent of watched directory"       | { it.parentFile }
-        "grand-parent of watched directory" | { it.parentFile.parentFile }
+        ancestry                            | removedDirectory             | canDeleteDirectory
+        "watched directory"                 | { it }                       | true
+        "parent of watched directory"       | { it.parentFile }            | !OperatingSystem.current.windows
+        "grand-parent of watched directory" | { it.parentFile.parentFile } | !OperatingSystem.current.windows
     }
 
     @Unroll

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -617,7 +617,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
             : Platform.current().windows
             ? [event(MODIFIED, removedFile), event(REMOVED, removedFile, false), event(REMOVED, watchedDir)]
             : [event(REMOVED, removedFile), event(REMOVED, watchedDir)]
-        removedDir.deleteDir()
+        assert removedDir.deleteDir()
 
         then:
         expectedChanges.await()

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -189,7 +189,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def watcher = startNewWatcher(callback)
         watcher.startWatching(watchedDir)
         Thread.sleep(500)
-        deleteRecursively(rootDir)
+        deleteRecursively(watchedDir)
 
         then:
         watcher.close()

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -19,9 +19,7 @@ package net.rubygrapefruit.platform.file
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Requires
 import spock.lang.Timeout
-import spock.util.environment.OperatingSystem
 
-import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 
@@ -189,38 +187,10 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def watcher = startNewWatcher(callback)
         watcher.startWatching(watchedDir)
         Thread.sleep(500)
-        deleteRecursively(watchedDir)
+        assert watchedDir.deleteDir()
 
         then:
         watcher.close()
-    }
-
-    private static void deleteRecursively(File dir) {
-        java.nio.file.Files.walk(dir.toPath())
-            .sorted(Comparator.reverseOrder())
-            .forEach { path -> tryHardToDelete(path) }
-    }
-
-    protected static boolean tryHardToDelete(Path path) {
-        java.nio.file.Files.delete(path)
-        if (!java.nio.file.Files.exists(path)) {
-            return true
-        }
-
-        // This is copied from Ant (see org.apache.tools.ant.util.FileUtils.tryHardToDelete).
-        // It mentions that there is a bug in the Windows JDK implementations that this is a valid
-        // workaround for. I've been unable to find a definitive reference to this bug.
-        // The thinking is that if this is good enough for Ant, it's good enough for us.
-        if (OperatingSystem.current.windows) {
-            System.gc()
-        }
-        try {
-            Thread.sleep(10)
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt()
-        }
-
-        java.nio.file.Files.delete(path)
     }
 
     protected static List<File> createSubdirs(File root, int number) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -19,7 +19,9 @@ package net.rubygrapefruit.platform.file
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Requires
 import spock.lang.Timeout
+import spock.util.environment.OperatingSystem
 
+import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 
@@ -196,7 +198,29 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
     private static void deleteRecursively(File dir) {
         java.nio.file.Files.walk(dir.toPath())
             .sorted(Comparator.reverseOrder())
-            .forEach { path -> java.nio.file.Files.delete(path) }
+            .forEach { path -> tryHardToDelete(path) }
+    }
+
+    protected static boolean tryHardToDelete(Path path) {
+        java.nio.file.Files.delete(path)
+        if (!java.nio.file.Files.exists(path)) {
+            return true
+        }
+
+        // This is copied from Ant (see org.apache.tools.ant.util.FileUtils.tryHardToDelete).
+        // It mentions that there is a bug in the Windows JDK implementations that this is a valid
+        // workaround for. I've been unable to find a definitive reference to this bug.
+        // The thinking is that if this is good enough for Ant, it's good enough for us.
+        if (OperatingSystem.current.windows) {
+            System.gc()
+        }
+        try {
+            Thread.sleep(10)
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt()
+        }
+
+        java.nio.file.Files.delete(path)
     }
 
     protected static List<File> createSubdirs(File root, int number) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -187,10 +187,16 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def watcher = startNewWatcher(callback)
         watcher.startWatching(watchedDir)
         Thread.sleep(500)
-        assert rootDir.deleteDir()
+        deleteRecursively(rootDir)
 
         then:
         watcher.close()
+    }
+
+    private static void deleteRecursively(File dir) {
+        java.nio.file.Files.walk(dir.toPath())
+            .sorted(Comparator.reverseOrder())
+            .forEach { path -> java.nio.file.Files.delete(path) }
     }
 
     protected static List<File> createSubdirs(File root, int number) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -149,11 +149,12 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         watchedDirectories.each {
             watcher.startWatching(it)
         }
-        Thread.sleep(500)
+        waitForChangeEventLatency()
         assert rootDir.deleteDir()
+        watcher.close()
 
         then:
-        watcher.close()
+        noExceptionThrown()
     }
 
     @Requires({ !Platform.current().linux })
@@ -186,11 +187,12 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         when:
         def watcher = startNewWatcher(callback)
         watcher.startWatching(watchedDir)
-        Thread.sleep(500)
+        waitForChangeEventLatency()
         assert watchedDir.deleteDir()
+        watcher.close()
 
         then:
-        watcher.close()
+        noExceptionThrown()
     }
 
     protected static List<File> createSubdirs(File root, int number) {


### PR DESCRIPTION
This is similar to the test on Linux, only for the hierarchical
watchers.