### PR TITLE
Allow (un)registering multiple paths at once

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -208,7 +208,7 @@ void Server::unregisterPath(const u16string& path) {
 }
 
 JNIEXPORT jobject JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatcher(JNIEnv* env, jclass, long latencyInMillis, jobject javaCallback) {
+Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatcher0(JNIEnv* env, jclass, long latencyInMillis, jobject javaCallback) {
     return wrapServer(env, [env, javaCallback, latencyInMillis]() {
         return new Server(env, javaCallback, latencyInMillis);
     });

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -89,14 +89,11 @@ Server::Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis)
 }
 
 Server::~Server() {
-    // Make copy of watch point paths to avoid race conditions
-    list<u16string> paths;
+    vector<u16string> paths(watchPoints.size());
     for (auto& watchPoint : watchPoints) {
         paths.push_back(watchPoint.first);
     }
-    for (auto& path : paths) {
-        executeOnThread(shared_ptr<Command>(new UnregisterPathCommand(path)));
-    }
+    executeOnThread(shared_ptr<Command>(new UnregisterPathsCommand(paths)));
     executeOnThread(shared_ptr<Command>(new TerminateCommand()));
 
     if (watcherThread.joinable()) {

--- a/src/file-events/cpp/file-events-version.cpp
+++ b/src/file-events/cpp/file-events-version.cpp
@@ -2,6 +2,6 @@
 #include "net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions.h"
 
 JNIEXPORT jstring JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_getVersion(JNIEnv* env, jclass) {
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_getVersion0(JNIEnv* env, jclass) {
     return env->NewStringUTF(NATIVE_VERSION);
 }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -165,6 +165,16 @@ u16string javaToUtf16String(JNIEnv* env, jstring javaString) {
     return path;
 }
 
+void javaToUtf16StringArray(JNIEnv* env, jobjectArray javaStrings, vector<u16string>& strings) {
+    int count = env->GetArrayLength(javaStrings);
+    strings.reserve(count);
+    for (int i = 0; i < count; i++) {
+        jstring javaString = reinterpret_cast<jstring>(env->GetObjectArrayElement(javaStrings, i));
+        auto string = javaToUtf16String(env, javaString);
+        strings.push_back(string);
+    }
+}
+
 // Utility wrapper to adapt locale-bound facets for wstring convert
 // Exposes the protected destructor as public
 // See https://en.cppreference.com/w/cpp/locale/codecvt
@@ -217,12 +227,26 @@ jobject wrapServer(JNIEnv* env, function<void*()> serverStarter) {
     return env->NewObject(jniConstants->nativeFileWatcherClass.get(), constructor, env->NewDirectByteBuffer(server, sizeof(server)));
 }
 
+void AbstractServer::registerPaths(const vector<u16string>& paths) {
+    for (auto& path : paths) {
+        registerPath(path);
+    }
+}
+
+void AbstractServer::unregisterPaths(const vector<u16string>& paths) {
+    for (auto& path : paths) {
+        unregisterPath(path);
+    }
+}
+
 JNIEXPORT void JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_startWatching(JNIEnv* env, jobject, jobject javaServer, jstring javaPath) {
     try {
         AbstractServer* server = getServer(env, javaServer);
         auto path = javaToUtf16String(env, javaPath);
-        server->executeOnThread(shared_ptr<Command>(new RegisterPathCommand(path)));
+        vector<u16string> paths;
+        paths.push_back(path);
+        server->executeOnThread(shared_ptr<Command>(new RegisterPathsCommand(paths)));
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
     }
@@ -233,7 +257,9 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
     try {
         AbstractServer* server = getServer(env, javaServer);
         auto path = javaToUtf16String(env, javaPath);
-        server->executeOnThread(shared_ptr<Command>(new UnregisterPathCommand(path)));
+        vector<u16string> paths;
+        paths.push_back(path);
+        server->executeOnThread(shared_ptr<Command>(new UnregisterPathsCommand(paths)));
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
     }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -171,7 +171,7 @@ void javaToUtf16StringArray(JNIEnv* env, jobjectArray javaStrings, vector<u16str
     for (int i = 0; i < count; i++) {
         jstring javaString = reinterpret_cast<jstring>(env->GetObjectArrayElement(javaStrings, i));
         auto string = javaToUtf16String(env, javaString);
-        strings.push_back(string);
+        strings.push_back(move(string));
     }
 }
 

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -240,7 +240,7 @@ void AbstractServer::unregisterPaths(const vector<u16string>& paths) {
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_startWatching(JNIEnv* env, jobject, jobjectArray javaPaths, jobject javaServer) {
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_startWatching0(JNIEnv* env, jobject, jobject javaServer, jobjectArray javaPaths) {
     try {
         AbstractServer* server = getServer(env, javaServer);
         vector<u16string> paths;
@@ -252,7 +252,7 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_stopWatching(JNIEnv* env, jobject, jobjectArray javaPaths, jobject javaServer) {
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_stopWatching0(JNIEnv* env, jobject, jobject javaServer, jobjectArray javaPaths) {
     try {
         AbstractServer* server = getServer(env, javaServer);
         vector<u16string> paths;
@@ -264,7 +264,7 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_stop(JNIEnv* env, jobject, jobject javaServer) {
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_close0(JNIEnv* env, jobject, jobject javaServer) {
     try {
         AbstractServer* server = getServer(env, javaServer);
         delete server;
@@ -273,7 +273,7 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
     }
 }
 
-JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_invalidateLogLevelCache(JNIEnv*, jobject) {
+JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_invalidateLogLevelCache0(JNIEnv*, jobject) {
     logging->invalidateLogLevelCache();
 }
 

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -240,12 +240,11 @@ void AbstractServer::unregisterPaths(const vector<u16string>& paths) {
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_startWatching(JNIEnv* env, jobject, jobject javaServer, jstring javaPath) {
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_startWatching(JNIEnv* env, jobject, jobjectArray javaPaths, jobject javaServer) {
     try {
         AbstractServer* server = getServer(env, javaServer);
-        auto path = javaToUtf16String(env, javaPath);
         vector<u16string> paths;
-        paths.push_back(path);
+        javaToUtf16StringArray(env, javaPaths, paths);
         server->executeOnThread(shared_ptr<Command>(new RegisterPathsCommand(paths)));
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
@@ -253,12 +252,11 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_stopWatching(JNIEnv* env, jobject, jobject javaServer, jstring javaPath) {
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_stopWatching(JNIEnv* env, jobject, jobjectArray javaPaths, jobject javaServer) {
     try {
         AbstractServer* server = getServer(env, javaServer);
-        auto path = javaToUtf16String(env, javaPath);
         vector<u16string> paths;
-        paths.push_back(path);
+        javaToUtf16StringArray(env, javaPaths, paths);
         server->executeOnThread(shared_ptr<Command>(new UnregisterPathsCommand(paths)));
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -276,7 +276,7 @@ void Server::unregisterPath(const u16string& path) {
 }
 
 JNIEXPORT jobject JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_startWatcher(JNIEnv* env, jclass, jobject javaCallback) {
+Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_startWatcher0(JNIEnv* env, jclass, jobject javaCallback) {
     return wrapServer(env, [env, javaCallback]() {
         return new Server(env, javaCallback);
     });

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -371,7 +371,7 @@ void Server::unregisterPath(const u16string& path) {
 //
 
 JNIEXPORT jobject JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatcher(JNIEnv* env, jclass target, jobject javaCallback) {
+Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatcher0(JNIEnv* env, jclass target, jobject javaCallback) {
     return wrapServer(env, [env, javaCallback]() {
         return new Server(env, javaCallback);
     });

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -5,12 +5,12 @@
 #include <exception>
 #include <functional>
 #include <iostream>
-#include <list>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "jni_support.h"
 #include "logging.h"
@@ -103,16 +103,16 @@ public:
     void processCommands();
 
     /**
-     * Registers a new watch point with the server.
+     * Registers new watch point with the server for the given paths.
      * Runs on processing thread.
      */
-    virtual void registerPath(const u16string& path) = 0;
+    void registerPaths(const vector<u16string>& paths);
 
     /**
-     * Unregisters a new watch point with the server.
+     * Unregisters watch points with the server for the given paths.
      * Runs on processing thread.
      */
-    virtual void unregisterPath(const u16string& path) = 0;
+    void unregisterPaths(const vector<u16string>& paths);
 
     /**
      * Terminates server.
@@ -121,6 +121,9 @@ public:
     virtual void terminate() = 0;
 
 protected:
+    virtual void registerPath(const u16string& path) = 0;
+    virtual void unregisterPath(const u16string& path) = 0;
+
     void reportChange(JNIEnv* env, int type, const u16string& path);
     void reportError(JNIEnv* env, const exception& ex);
 
@@ -145,32 +148,32 @@ private:
     jmethodID watcherReportErrorMethod;
 };
 
-class RegisterPathCommand : public Command {
+class RegisterPathsCommand : public Command {
 public:
-    RegisterPathCommand(const u16string& path)
-        : path(path) {
+    RegisterPathsCommand(const vector<u16string>& paths)
+        : paths(paths) {
     }
 
     void perform(AbstractServer* server) override {
-        server->registerPath(path);
+        server->registerPaths(paths);
     }
 
 private:
-    u16string path;
+    const vector<u16string> paths;
 };
 
-class UnregisterPathCommand : public Command {
+class UnregisterPathsCommand : public Command {
 public:
-    UnregisterPathCommand(const u16string& path)
-        : path(path) {
+    UnregisterPathsCommand(const vector<u16string>& paths)
+        : paths(paths) {
     }
 
     void perform(AbstractServer* server) override {
-        server->unregisterPath(path);
+        server->unregisterPaths(paths);
     }
 
 private:
-    u16string path;
+    const vector<u16string> paths;
 };
 
 class TerminateCommand : public Command {

--- a/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
@@ -8,9 +8,9 @@ import java.io.IOException;
  * A handle for watching file system locations.
  */
 public interface FileWatcher extends Closeable {
-    void startWatching(File path);
+    void startWatching(File... paths);
 
-    void stopWatching(File path);
+    void stopWatching(File... paths);
 
     /**
      * Stops watching and releases any native resources.

--- a/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
@@ -3,14 +3,15 @@ package net.rubygrapefruit.platform.file;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * A handle for watching file system locations.
  */
 public interface FileWatcher extends Closeable {
-    void startWatching(File... paths);
+    void startWatching(Collection<File> paths);
 
-    void stopWatching(File... paths);
+    void stopWatching(Collection<File> paths);
 
     /**
      * Stops watching and releases any native resources.

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -6,6 +6,7 @@ import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.file.FileWatcherCallback;
 
 import java.io.File;
+import java.util.Collection;
 
 public class AbstractFileEventFunctions implements NativeIntegration {
     public static native String getVersion();
@@ -49,7 +50,7 @@ public class AbstractFileEventFunctions implements NativeIntegration {
         }
 
         @Override
-        public void startWatching(File... paths) {
+        public void startWatching(Collection<File> paths) {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
@@ -59,7 +60,7 @@ public class AbstractFileEventFunctions implements NativeIntegration {
         private native void startWatching(String[] absolutePaths, Object server);
 
         @Override
-        public void stopWatching(File... paths) {
+        public void stopWatching(Collection<File> paths) {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
@@ -68,8 +69,8 @@ public class AbstractFileEventFunctions implements NativeIntegration {
 
         private native void stopWatching(String[] absolutePaths, Object server);
 
-        private static String[] toAbsolutePaths(File[] files) {
-            String[] paths = new String[files.length];
+        private static String[] toAbsolutePaths(Collection<File> files) {
+            String[] paths = new String[files.size()];
             int index = 0;
             for (File file : files) {
                 paths[index++] = file.getAbsolutePath();

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -49,24 +49,33 @@ public class AbstractFileEventFunctions implements NativeIntegration {
         }
 
         @Override
-        public void startWatching(File path) {
+        public void startWatching(File... paths) {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
-            startWatching(server, path.getAbsolutePath());
+            startWatching(toAbsolutePaths(paths), server);
         }
 
-        private native void startWatching(Object server, String absolutePath);
+        private native void startWatching(String[] absolutePaths, Object server);
 
         @Override
-        public void stopWatching(File path) {
+        public void stopWatching(File... paths) {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
-            stopWatching(server, path.getAbsolutePath());
+            stopWatching(toAbsolutePaths(paths), server);
         }
 
-        private native void stopWatching(Object server, String absolutePath);
+        private native void stopWatching(String[] absolutePaths, Object server);
+
+        private static String[] toAbsolutePaths(File[] files) {
+            String[] paths = new String[files.length];
+            int index = 0;
+            for (File file : files) {
+                paths[index++] = file.getAbsolutePath();
+            }
+            return paths;
+        }
 
         @Override
         public void close() {

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -9,13 +9,21 @@ import java.io.File;
 import java.util.Collection;
 
 public class AbstractFileEventFunctions implements NativeIntegration {
-    public static native String getVersion();
+    public static String getVersion() {
+        return getVersion0();
+    }
+
+    private static native String getVersion0();
 
     /**
      * Forces the native backend to drop the cached JUL log level and thus
      * re-query it the next time it tries to log something to the Java side.
      */
-    public native void invalidateLogLevelCache();
+    public void invalidateLogLevelCache() {
+        invalidateLogLevelCache0();
+    }
+
+    private native void invalidateLogLevelCache0();
 
     protected static class NativeFileWatcherCallback {
         private final FileWatcherCallback delegate;
@@ -54,20 +62,20 @@ public class AbstractFileEventFunctions implements NativeIntegration {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
-            startWatching(toAbsolutePaths(paths), server);
+            startWatching0(server, toAbsolutePaths(paths));
         }
 
-        private native void startWatching(String[] absolutePaths, Object server);
+        private native void startWatching0(Object server, String[] absolutePaths);
 
         @Override
         public void stopWatching(Collection<File> paths) {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
-            stopWatching(toAbsolutePaths(paths), server);
+            stopWatching0(server, toAbsolutePaths(paths));
         }
 
-        private native void stopWatching(String[] absolutePaths, Object server);
+        private native void stopWatching0(Object server, String[] absolutePaths);
 
         private static String[] toAbsolutePaths(Collection<File> files) {
             String[] paths = new String[files.size()];
@@ -83,10 +91,10 @@ public class AbstractFileEventFunctions implements NativeIntegration {
             if (server == null) {
                 throw new NativeException("Closed already");
             }
-            stop(server);
+            close0(server);
             server = null;
         }
 
-        protected native void stop(Object details);
+        protected native void close0(Object details);
     }
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -33,8 +33,8 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
      * </ul>
      */
     public FileWatcher startWatcher(FileWatcherCallback callback) {
-        return startWatcher(new NativeFileWatcherCallback(callback));
+        return startWatcher0(new NativeFileWatcherCallback(callback));
     }
 
-    private static native FileWatcher startWatcher(NativeFileWatcherCallback callback);
+    private static native FileWatcher startWatcher0(NativeFileWatcherCallback callback);
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -60,8 +60,8 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
      */
     // TODO How to set kFSEventStreamCreateFlagNoDefer when latency is non-zero?
     public FileWatcher startWatcher(long latency, TimeUnit unit, FileWatcherCallback callback) {
-        return startWatcher(unit.toMillis(latency), new NativeFileWatcherCallback(callback));
+        return startWatcher0(unit.toMillis(latency), new NativeFileWatcherCallback(callback));
     }
 
-    private static native FileWatcher startWatcher(long latencyInMillis, NativeFileWatcherCallback callback);
+    private static native FileWatcher startWatcher0(long latencyInMillis, NativeFileWatcherCallback callback);
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -52,8 +52,8 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
     // TODO What about symlinks?
     // TODO What about SUBST drives?
     public FileWatcher startWatcher(FileWatcherCallback callback) {
-        return startWatcher(new NativeFileWatcherCallback(callback));
+        return startWatcher0(new NativeFileWatcherCallback(callback));
     }
 
-    private static native FileWatcher startWatcher(NativeFileWatcherCallback callback);
+    private static native FileWatcher startWatcher0(NativeFileWatcherCallback callback);
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -54,7 +54,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
     def callback = new TestCallback()
     File testDir
     File rootDir
-    FileWatcher watcher
+    TestFileWatcher watcher
     List<Throwable> uncaughtFailureOnThread
 
     // We could do this with @Delegate, but Groovy doesn't let us :(
@@ -91,7 +91,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
 
             @Override
-            FileWatcher startNewWatcher(FileWatcherCallback callback) {
+            FileWatcher startNewWatcherInternal(FileWatcherCallback callback) {
                 // Avoid setup operations to be reported
                 waitForChangeEventLatency()
                 service.startWatcher(
@@ -113,7 +113,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
 
             @Override
-            FileWatcher startNewWatcher(FileWatcherCallback callback) {
+            FileWatcher startNewWatcherInternal(FileWatcherCallback callback) {
                 // Avoid setup operations to be reported
                 waitForChangeEventLatency()
                 service.startWatcher(callback)
@@ -132,7 +132,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
 
             @Override
-            FileWatcher startNewWatcher(FileWatcherCallback callback) {
+            FileWatcher startNewWatcherInternal(FileWatcherCallback callback) {
                 service.startWatcher(callback)
             }
 
@@ -148,7 +148,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             }
 
             @Override
-            FileWatcher startNewWatcher(FileWatcherCallback callback) {
+            FileWatcher startNewWatcherInternal(FileWatcherCallback callback) {
                 throw new UnsupportedOperationException()
             }
 
@@ -172,7 +172,11 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
 
         abstract AbstractFileEventFunctions getService();
 
-        abstract FileWatcher startNewWatcher(FileWatcherCallback callback)
+        abstract FileWatcher startNewWatcherInternal(FileWatcherCallback callback)
+
+        TestFileWatcher startNewWatcher(FileWatcherCallback callback) {
+            new TestFileWatcher(startNewWatcherInternal(callback))
+        }
 
         abstract void waitForChangeEventLatency()
     }
@@ -242,7 +246,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         watcherFixture.service
     }
 
-    protected FileWatcher startNewWatcher(FileWatcherCallback callback) {
+    protected TestFileWatcher startNewWatcher(FileWatcherCallback callback) {
         watcherFixture.startNewWatcher(callback)
     }
 
@@ -281,5 +285,22 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         LOGGER.info("> Creating $file")
         file.createNewFile()
         LOGGER.info("< Created $file")
+    }
+
+    static class TestFileWatcher implements FileWatcher {
+        @Delegate
+        private final FileWatcher delegate
+
+        TestFileWatcher(FileWatcher delegate) {
+            this.delegate = delegate
+        }
+
+        void startWatching(File... paths) {
+            delegate.startWatching(paths as List)
+        }
+
+        void stopWatching(File... paths) {
+            delegate.stopWatching(paths as List)
+        }
     }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -252,9 +252,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
 
     protected void startWatcher(FileWatcherCallback callback = this.callback, File... roots) {
         watcher = startNewWatcher(callback)
-        roots*.absoluteFile.each { root ->
-            watcher.startWatching(root)
-        }
+        watcher.startWatching(roots)
     }
 
     protected void stopWatcher() {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -100,9 +100,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
             }
             executorService.shutdown()
 
-            watchedDirectories.each {
-                watcher.startWatching(it)
-            }
+            watcher.startWatching(watchedDirectories as File[])
             readyLatch.await()
             startModifyingLatch.countDown()
             Thread.sleep(500)
@@ -146,9 +144,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         when:
         def watcher = startNewWatcher(callback)
-        watchedDirectories.each {
-            watcher.startWatching(it)
-        }
+        watcher.startWatching(watchedDirectories as File[])
         Thread.sleep(500)
         assert rootDir.deleteDir()
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -57,7 +57,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         expectedChanges.await()
     }
 
-    def "can stop and restart watching many directory times"() {
+    def "can stop and restart watching many directory many times"() {
         given:
         File[] watchedDirs = createDirectoriesToWatch(100)
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -95,7 +95,6 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         expect:
         20.times { iteration ->
             def watchedDirectories = createDirectoriesToWatch(numberOfWatchedDirectories, "iteration-$iteration/watchedDir-")
-            watchedDirectories.each { assert it.mkdirs() }
 
             def executorService = Executors.newFixedThreadPool(numberOfParallelWritersPerWatchedDirectory * numberOfWatchedDirectories)
             def readyLatch = new CountDownLatch(numberOfParallelWritersPerWatchedDirectory * numberOfWatchedDirectories)
@@ -179,7 +178,10 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
     }
 
     private List<File> createDirectoriesToWatch(int numberOfWatchedDirectories, String prefix = "dir-") {
-        (1..numberOfWatchedDirectories).collect { new File(rootDir, prefix + it) }
+        (1..numberOfWatchedDirectories).collect {
+            def dir = new File(rootDir, prefix + it)
+            assert dir.mkdirs()
+            return dir
+        }
     }
 }
-

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -414,13 +415,13 @@ public class Main {
     private static FileWatcher createMacOsFileWatcher(String path, FileWatcherCallback callback) throws IOException {
         FileWatcher fileWatcher = Native.get(OsxFileEventFunctions.class)
             .startWatcher(300, TimeUnit.MILLISECONDS, callback);
-        fileWatcher.startWatching(new File(path));
+        fileWatcher.startWatching(Collections.singleton(new File(path)));
         return fileWatcher;
     }
 
     private static FileWatcher createWindowsFileWatcher(String path, FileWatcherCallback callback) {
         FileWatcher fileWatcher = Native.get(WindowsFileEventFunctions.class).startWatcher(callback);
-        fileWatcher.startWatching(new File(path));
+        fileWatcher.startWatching(Collections.singleton(new File(path)));
         return fileWatcher;
     }
 


### PR DESCRIPTION
On Windows and macOS typically we only want to watch a small number of paths that don't change over time, as each path is watched recursively. However, on Linux watch points need to be (un)registered frequently and en masse. The current API requires each change to be communicated to the server in a separately synchronized `Command` which is slow. Instead we want to allow the application to pass a number of watch points in at the same time.