### PR TITLE
Use a BlockingQueue to pass events to the Java side

### DIFF
--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -59,7 +59,7 @@ void AbstractServer::reportChange(JNIEnv* env, FileWatchEventType type, const u1
     jstring javaPath = env->NewString((jchar*) path.c_str(), (jsize) path.length());
     env->CallVoidMethod(watcherCallback.get(), watcherCallbackMethod, type, javaPath);
     env->DeleteLocalRef(javaPath);
-    rethrowJavaException(env);
+    logJavaException(env);
 }
 
 void AbstractServer::reportError(JNIEnv* env, const exception& exception) {
@@ -70,7 +70,7 @@ void AbstractServer::reportError(JNIEnv* env, const exception& exception) {
     env->CallVoidMethod(watcherCallback.get(), watcherReportErrorMethod, javaException);
     env->DeleteLocalRef(javaMessage);
     env->DeleteLocalRef(javaException);
-    rethrowJavaException(env);
+    logJavaException(env);
 }
 
 AbstractServer* getServer(JNIEnv* env, jobject javaServer) {

--- a/src/file-events/cpp/jni_support.cpp
+++ b/src/file-events/cpp/jni_support.cpp
@@ -33,8 +33,17 @@ JNIEnv* JniSupport::getThreadEnv() {
     return env;
 }
 
-void JniSupport::rethrowJavaException(JNIEnv* env) {
+jthrowable JniSupport::logJavaException(JNIEnv* env) {
     jthrowable exception = env->ExceptionOccurred();
+    if (exception != nullptr) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+    return exception;
+}
+
+void JniSupport::rethrowJavaException(JNIEnv* env) {
+    jthrowable exception = logJavaException(env);
     if (exception != nullptr) {
         env->ExceptionDescribe();
         env->ExceptionClear();

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -141,6 +141,8 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         if (errorCode != ERROR_SUCCESS) {
             if (errorCode == ERROR_ACCESS_DENIED && !watchPoint->isValidDirectory()) {
                 reportChange(env, REMOVED, path);
+                watchPoint->close();
+                return;
             } else {
                 throw FileWatcherException("Error received when handling events", path, errorCode);
             }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -63,6 +63,7 @@ WatchPoint::~WatchPoint() {
         if (cancel()) {
             SleepEx(0, true);
         }
+        close();
     } catch (const exception& ex) {
         logToJava(WARNING, "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
     }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -279,9 +279,9 @@ Server::Server(JNIEnv* env, size_t bufferSize, jobject watcherCallback)
 void Server::initializeRunLoop() {
     // TODO For some reason GetCurrentThread() returns a thread that doesn't accept APCs
     threadHandle = OpenThread(
-        THREAD_ALL_ACCESS,
-        false,
-        GetCurrentThreadId()
+        THREAD_ALL_ACCESS,      // dwDesiredAccess
+        false,                  // bInheritHandle
+        GetCurrentThreadId()    // dwThreadId
     );
     if (threadHandle == NULL) {
         throw FileWatcherException("Couldn't open current thread", GetLastError());

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -41,9 +41,10 @@ WatchPoint::WatchPoint(Server* server, size_t bufferSize, const u16string& path)
 bool WatchPoint::cancel() {
     if (status == LISTENING) {
         logToJava(FINE, "Cancelling %s", utf16ToUtf8String(path).c_str());
-        status = CANCELLED;
         bool cancelled = (bool) CancelIoEx(directoryHandle, &overlapped);
-        if (!cancelled) {
+        if (cancelled) {
+            status = CANCELLED;
+        } else {
             DWORD cancelError = GetLastError();
             close();
             if (cancelError == ERROR_NOT_FOUND) {

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -147,7 +147,16 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         }
 
         if (bytesTransferred == 0) {
-            // Got a buffer overflow => current changes lost => send OVERFLOWED on root
+            // This is what the documentation has to says about a zero-length dataset:
+            //
+            //     If the number of bytes transferred is zero, the buffer was either too large
+            //     for the system to allocate or too small to provide detailed information on
+            //     all the changes that occurred in the directory or subtree. In this case,
+            //     you should compute the changes by enumerating the directory or subtree.
+            //
+            // (See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw)
+            //
+            // We'll handle this as a simple overflow and report it as such.
             logToJava(INFO, "Detected overflow for %s", utf16ToUtf8String(path).c_str());
             reportChange(env, OVERFLOWED, path);
         } else {

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -147,7 +147,7 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         }
 
         if (bytesTransferred == 0) {
-            // This is what the documentation has to says about a zero-length dataset:
+            // This is what the documentation has to say about a zero-length dataset:
             //
             //     If the number of bytes transferred is zero, the buffer was either too large
             //     for the system to allocate or too small to provide detailed information on
@@ -175,6 +175,7 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
             case SUCCESS:
                 break;
             case DELETED:
+                logToJava(FINE, "Watched directory removed for %s", utf16ToUtf8String(path).c_str());
                 reportChange(env, REMOVED, path);
                 break;
         }

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-// Corresponds to values of FileWatcherCallback.Type
+// Corresponds to values of FileWatchEvent.Type
 enum FileWatchEventType {
     CREATED,
     REMOVED,

--- a/src/file-events/headers/jni_support.h
+++ b/src/file-events/headers/jni_support.h
@@ -19,6 +19,11 @@ public:
     JniSupport(JNIEnv* env);
 
     /**
+     * Check for a Java exception and log it.
+     */
+    static jthrowable logJavaException(JNIEnv* env);
+
+    /**
      * Check for a Java exception and rethrow as a native exception.
      */
     static void rethrowJavaException(JNIEnv* env);

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -45,6 +45,7 @@ public:
 
 private:
     bool isValidDirectory();
+    void close();
 
     Server* server;
     const u16string path;

--- a/src/main/java/net/rubygrapefruit/platform/file/FileWatchEvent.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/FileWatchEvent.java
@@ -1,11 +1,20 @@
 package net.rubygrapefruit.platform.file;
 
-/**
- * A callback that is invoked whenever a path has changed.
- */
-public interface FileWatcherCallback {
+import javax.annotation.Nullable;
+
+public interface FileWatchEvent {
+
     /**
-     * The given path has changed.
+     * The type of the change. When {@link Type#FAILURE}, {@link #getFailure()} returns
+     * the failure, and {@link #getPath()} returns {@code null}.
+     * Otherwise {@link #getFailure()} returns {@code null} and {@link #getPath()}
+     * returns either the path of the change, or {@code null} if a path is not known.
+     */
+    Type getType();
+
+    /**
+     * The path that has been changed. Can be {@code null} when {@link #getType()} is
+     * {@link Type#FAILURE} or {@link Type#UNKNOWN}.
      *
      * See notes on the {@link FileWatcher} implementation for:
      *
@@ -13,16 +22,15 @@ public interface FileWatcherCallback {
      *     <li>whether calls to this method can be expected from a single thread or multiple different ones,</li>
      *     <li>how actual events are reported.</li>
      * </ul>
-     *
-     * @param type the type of the change.
-     * @param path the path of the change.
-     *             For {@link Type#UNKNOWN} it can be {@code null}.
      */
-    // Invoked from native code
-    @SuppressWarnings("unused")
-    void pathChanged(Type type, String path);
+    @Nullable
+    String getPath();
 
-    void reportError(Throwable ex);
+    /**
+     * Returns the failure encountered when {@link #getType()} is {@link Type#FAILURE}, otherwise {@code null}.
+     */
+    @Nullable
+    Throwable getFailure();
 
     enum Type {
         /**
@@ -55,6 +63,13 @@ public interface FileWatcherCallback {
          * An unknown event happened to the given path or some of its descendants,
          * discard all information about the file system.
          */
-        UNKNOWN
+        UNKNOWN,
+
+        /**
+         * An error happened to the given path or some of its descendants.
+         *
+         * @see FileWatchEvent#getFailure()
+         */
+        FAILURE
     }
 }

--- a/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
@@ -15,7 +15,7 @@ public interface FileWatcher extends Closeable {
 
     /**
      * Stops watching and releases any native resources.
-     * No more calls to the associated {@link FileWatcherCallback} will happen after this method returns.
+     * No more events will arrive after this method returns.
      */
     @Override
     void close() throws IOException;

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -10,7 +10,6 @@ import java.io.InterruptedIOException;
 import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -78,8 +77,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
         }
 
         private void queueEvent(FileWatchEvent event, boolean deliverOnOverflow) throws InterruptedException {
-            // TODO Make the timeout configurable
-            if (!eventQueue.offer(event, 1, SECONDS)) {
+            if (!eventQueue.offer(event)) {
                 NativeLogger.LOGGER.info("Event queue overflow, dropping all events");
                 signalOverflow(null);
                 if (deliverOnOverflow) {

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -65,7 +65,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
         public void pathChanged(int typeIndex, String path) throws InterruptedException {
             FileWatchEvent.Type type = FileWatchEvent.Type.values()[typeIndex];
             if (type == FileWatchEvent.Type.OVERFLOWED) {
-                signalOverflow();
+                signalOverflow(path);
             } else {
                 queueEvent(new ChangeEvent(type, path), false);
             }
@@ -81,16 +81,16 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
             // TODO Make the timeout configurable
             if (!eventQueue.offer(event, 1, SECONDS)) {
                 NativeLogger.LOGGER.info("Event queue overflow, dropping all events");
-                signalOverflow();
+                signalOverflow(null);
                 if (deliverOnOverflow) {
                     eventQueue.put(event);
                 }
             }
         }
 
-        private void signalOverflow() throws InterruptedException {
+        private void signalOverflow(@Nullable String path) throws InterruptedException {
             eventQueue.clear();
-            eventQueue.put(new ChangeEvent(FileWatchEvent.Type.OVERFLOWED, null));
+            eventQueue.put(new ChangeEvent(FileWatchEvent.Type.OVERFLOWED, path));
         }
     }
 

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -62,7 +62,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
         @SuppressWarnings("unused")
         public void pathChanged(int typeIndex, String path) throws InterruptedException {
             FileWatchEvent.Type type = FileWatchEvent.Type.values()[typeIndex];
-            eventQueue.put(new DefaultEvent(type, path));
+            eventQueue.put(new ChangeEvent(type, path));
         }
 
         // Called from the native side
@@ -147,11 +147,11 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
         }
     }
 
-    private static class DefaultEvent implements FileWatchEvent {
+    private static class ChangeEvent implements FileWatchEvent {
         private final Type type;
         private final String path;
 
-        public DefaultEvent(Type type, String path) {
+        public ChangeEvent(Type type, String path) {
             this.type = type;
             this.path = path;
         }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -16,9 +16,10 @@
 
 package net.rubygrapefruit.platform.internal.jni;
 
+import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
-import net.rubygrapefruit.platform.file.FileWatcherCallback;
 
+import java.util.concurrent.BlockingQueue;
 
 /**
  * File watcher for Linux. Reports changes to the watched paths and their immediate children.
@@ -35,18 +36,18 @@ import net.rubygrapefruit.platform.file.FileWatcherCallback;
 public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
 
     @Override
-    public WatcherBuilder newWatcher(FileWatcherCallback callback) {
-        return new WatcherBuilder(callback);
+    public WatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
+        return new WatcherBuilder(eventQueue);
     }
 
     public static class WatcherBuilder extends AbstractWatcherBuilder {
-        WatcherBuilder(FileWatcherCallback callback) {
-            super(callback);
+        WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
+            super(eventQueue);
         }
 
         @Override
         public FileWatcher start() throws InterruptedException {
-            return new NativeFileWatcher(startWatcher0(new NativeFileWatcherCallback(callback)));
+            return new NativeFileWatcher(startWatcher0(new NativeFileWatcherCallback(eventQueue)));
         }
     }
 

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/NativeLogger.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/NativeLogger.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 // Used from native
 @SuppressWarnings("unused")
 public class NativeLogger {
-    private static final Logger LOGGER = Logger.getLogger(NativeLogger.class.getName());
+    static final Logger LOGGER = Logger.getLogger(NativeLogger.class.getName());
 
     enum LogLevel {
         FINEST(Level.FINEST),

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -16,9 +16,10 @@
 
 package net.rubygrapefruit.platform.internal.jni;
 
+import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
-import net.rubygrapefruit.platform.file.FileWatcherCallback;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -45,15 +46,15 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
     private static final long DEFAULT_LATENCY_IN_MS = 0;
 
     @Override
-    public WatcherBuilder newWatcher(FileWatcherCallback callback) {
-        return new WatcherBuilder(callback);
+    public WatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
+        return new WatcherBuilder(eventQueue);
     }
 
     public static class WatcherBuilder extends AbstractWatcherBuilder {
         private long latencyInMillis = DEFAULT_LATENCY_IN_MS;
 
-        WatcherBuilder(FileWatcherCallback callback) {
-            super(callback);
+        WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
+            super(eventQueue);
         }
 
         /**
@@ -70,7 +71,7 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
 
         @Override
         public FileWatcher start() throws InterruptedException {
-            return new NativeFileWatcher(startWatcher0(latencyInMillis, new NativeFileWatcherCallback(callback)));
+            return new NativeFileWatcher(startWatcher0(latencyInMillis, new NativeFileWatcherCallback(eventQueue)));
         }
     }
 

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -16,8 +16,10 @@
 
 package net.rubygrapefruit.platform.internal.jni;
 
+import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
-import net.rubygrapefruit.platform.file.FileWatcherCallback;
+
+import java.util.concurrent.BlockingQueue;
 
 /**
  * File watcher for Windows. Reports changes to the watched paths and any of their descendants.
@@ -29,9 +31,9 @@ import net.rubygrapefruit.platform.file.FileWatcherCallback;
  *     different case, the canonical one is used to report changes.</li>
  *
  *     <li>When reporting
- *     {@link net.rubygrapefruit.platform.file.FileWatcherCallback.Type#REMOVED REMOVED}
+ *     {@link net.rubygrapefruit.platform.file.FileWatchEvent.Type#REMOVED REMOVED}
  *     events, Windows sometimes also reports a
- *     {@link net.rubygrapefruit.platform.file.FileWatcherCallback.Type#MODIFIED MODIFIED}
+ *     {@link net.rubygrapefruit.platform.file.FileWatchEvent.Type#MODIFIED MODIFIED}
  *     event for the same file. This can happen when deleting a file or renaming it.</li>
  *
  *     <li>Events arrive from a single background thread unique to the {@link FileWatcher}.
@@ -46,15 +48,15 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
     public static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
 
     @Override
-    public WatcherBuilder newWatcher(FileWatcherCallback callback) {
-        return new WatcherBuilder(callback);
+    public WatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
+        return new WatcherBuilder(eventQueue);
     }
 
     public static class WatcherBuilder extends AbstractWatcherBuilder {
         private int bufferSize = DEFAULT_BUFFER_SIZE;
 
-        private WatcherBuilder(FileWatcherCallback callback) {
-            super(callback);
+        private WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
+            super(eventQueue);
         }
 
         /**
@@ -68,7 +70,7 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
 
         @Override
         public FileWatcher start() throws InterruptedException {
-            return new NativeFileWatcher(startWatcher0(bufferSize, new NativeFileWatcherCallback(callback)));
+            return new NativeFileWatcher(startWatcher0(bufferSize, new NativeFileWatcherCallback(eventQueue)));
         }
     }
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -18,6 +18,7 @@ package net.rubygrapefruit.platform.file
 
 import groovy.transform.Memoized
 import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.file.FileWatchEvent.Type
 import net.rubygrapefruit.platform.internal.Platform
 import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions
 import net.rubygrapefruit.platform.internal.jni.LinuxFileEventFunctions
@@ -260,11 +261,11 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
     }
 
     private class ExpectedChange implements ExpectedEvent {
-        private final FileWatchEvent.Type type
+        private final Type type
         private final File file
         final boolean optional
 
-        ExpectedChange(FileWatchEvent.Type type, File file, boolean optional) {
+        ExpectedChange(Type type, File file, boolean optional) {
             this.type = type
             this.file = file
             this.optional = optional
@@ -292,7 +293,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
 
         @Override
         boolean matches(FileWatchEvent event) {
-            event.type == FileWatchEvent.Type.FAILURE \
+            event.type == Type.FAILURE \
                 && type.isInstance(event.failure) \
                 && message.matcher(event.failure.message).matches()
         }
@@ -414,11 +415,11 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             : path
     }
 
-    protected ExpectedEvent change(FileWatchEvent.Type type, File file) {
+    protected ExpectedEvent change(Type type, File file) {
         new ExpectedChange(type, file, false)
     }
 
-    protected ExpectedEvent optionalChange(FileWatchEvent.Type type, File file) {
+    protected ExpectedEvent optionalChange(Type type, File file) {
         return new ExpectedChange(type, file, true)
     }
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -359,7 +359,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             LOGGER.info("> Expecting $expectedEvent")
         }
         def remainingExpectedEvents = new ArrayList<ExpectedEvent>(expectedEvents)
-        def matchedEvents = new ArrayList<FileWatchEvent>()
+        def receivedEvents = new ArrayList<FileWatchEvent>()
         def unexpectedEvents = new ArrayList<FileWatchEvent>()
         expectEvents(
             eventQueue,
@@ -378,18 +378,18 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
                     unexpectedEvents << event
                 } else {
                     remainingExpectedEvents.remove(expectedEventIndex)
-                    matchedEvents << event
+                    receivedEvents << event
                 }
                 return true
             })
         Assert.that(
             remainingExpectedEvents.every { it.optional } && unexpectedEvents.empty,
-            createEventFailure(unexpectedEvents, remainingExpectedEvents, matchedEvents)
+            createEventFailure(unexpectedEvents, remainingExpectedEvents, receivedEvents)
         )
         ensureNoMoreEvents(eventQueue)
     }
 
-    private String createEventFailure(List<FileWatchEvent> unexpectedEvents, List<ExpectedEvent> remainingExpectedEvents, List<FileWatchEvent> matchedEvents) {
+    private String createEventFailure(List<FileWatchEvent> unexpectedEvents, List<ExpectedEvent> remainingExpectedEvents, List<FileWatchEvent> receivedEvents) {
         String failure = "Events received differ from expected:\n"
         unexpectedEvents.each { event ->
             failure += " - UNEXPECTED ${shorten(event)}\n"
@@ -397,8 +397,8 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         remainingExpectedEvents.each { event ->
             failure += " - MISSING    $event\n"
         }
-        matchedEvents.each { event ->
-            failure += " - MATCHED    ${shorten(event)}\n"
+        receivedEvents.each { event ->
+            failure += " - RECEIVED   ${shorten(event)}\n"
         }
         return failure
     }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -278,7 +278,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
 
         @Override
         String toString() {
-            return "${optional ? "optional " : ""}$type ${shorten(file)}"
+            return "${optional ? "optional " : ""}$type ${file == null ? null : shorten(file)}"
         }
     }
 
@@ -373,6 +373,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
                         throw new TimeoutException("Did not receive events in $timeoutValue ${timeoutUnit.name().toLowerCase()}:\n- " + expectedEvents.join("\n- "))
                     }
                 }
+                LOGGER.info("> Received $event")
                 def expectedEventIndex = expectedEvents.findIndexOf { expected ->
                     expected.matches(event)
                 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -24,7 +24,6 @@ import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Unroll
-import spock.util.concurrent.AsyncConditions
 import spock.util.environment.OperatingSystem
 
 import java.util.concurrent.ArrayBlockingQueue
@@ -35,10 +34,10 @@ import java.util.regex.Pattern
 import static java.util.logging.Level.INFO
 import static java.util.logging.Level.SEVERE
 import static java.util.logging.Level.WARNING
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.CREATED
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.INVALIDATED
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.MODIFIED
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.REMOVED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.CREATED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.INVALIDATED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.MODIFIED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.REMOVED
 
 @Unroll
 @Requires({ Platform.current().macOs || Platform.current().linux || Platform.current().windows })
@@ -514,34 +513,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         expectEvents change(CREATED, new File(reportedDir, fileInUppercaseDir.name))
     }
 
-    def "can handle exception in callback"() {
-        given:
-        def createdFile = new File(rootDir, "created.txt")
-        def conditions = new AsyncConditions()
-        when:
-        def watcher = startNewWatcher(new FileWatcherCallback() {
-            @Override
-            void pathChanged(FileWatcherCallback.Type type, String path) {
-                throw new RuntimeException("Error")
-            }
-
-            @Override
-            void reportError(Throwable ex) {
-                conditions.evaluate {
-                    assert ex instanceof NativeException
-                    assert ex.message == "Caught java.lang.RuntimeException with message: Error"
-                }
-            }
-        }, rootDir)
-        createNewFile(createdFile)
-
-        then:
-        conditions.await()
-
-        cleanup:
-        watcher.close()
-    }
-
     def "fails when stopped multiple times"() {
         given:
         def watcher = startNewWatcher()
@@ -782,31 +753,5 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         then:
         def exception = thrown(NativeException)
         exception.message == "Command execution timed out"
-    }
-
-    def "can throw exception with no message from callback"() {
-        def watchedDir = new File(rootDir, "watched")
-        watchedDir.mkdirs()
-        def error
-
-        when:
-        watcher = startNewWatcher(new FileWatcherCallback() {
-            @Override
-            void pathChanged(FileWatcherCallback.Type type, String path) {
-                throw new InterruptedException()
-            }
-
-            @Override
-            void reportError(Throwable ex) {
-                error = ex
-            }
-        }, watchedDir)
-        new File(watchedDir, "new").createNewFile()
-        waitForChangeEventLatency()
-
-        then:
-        noExceptionThrown()
-        error.getClass() == NativeException
-        error.message == "Caught ${InterruptedException.name}"
     }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -668,6 +668,10 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         when:
         def directoryRemoved = removedDir.deleteDir()
+        // On Windows we don't always manage to remove the watched directory, but it's unreliable
+        if (!Platform.current().windows) {
+            assert directoryRemoved
+        }
 
         def expectedEvents = []
         if (Platform.current().macOs) {
@@ -683,13 +687,12 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         expectEvents expectedEvents
-        directoryRemoved == expectDirectoryRemoved
 
         where:
-        ancestry                            | removedDirectory             | expectDirectoryRemoved
-        "watched directory"                 | { it }                       | true
-        "parent of watched directory"       | { it.parentFile }            | !OperatingSystem.current.windows
-        "grand-parent of watched directory" | { it.parentFile.parentFile } | !OperatingSystem.current.windows
+        ancestry                            | removedDirectory
+        "watched directory"                 | { it }
+        "parent of watched directory"       | { it.parentFile }
+        "grand-parent of watched directory" | { it.parentFile.parentFile }
     }
 
     def "can set log level by #action"() {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsOverflowTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsOverflowTest.groovy
@@ -26,8 +26,8 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 import static java.util.concurrent.TimeUnit.SECONDS
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.CREATED
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.OVERFLOWED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.CREATED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.OVERFLOWED
 
 @Ignore("Flaky")
 @Requires({ Platform.current().macOs || Platform.current().linux || Platform.current().windows })
@@ -79,7 +79,7 @@ class FileEventFunctionsOverflowTest extends AbstractFileEventFunctionsTest {
         executorService.shutdown()
     }
 
-    private boolean expectOverflow(BlockingQueue<RecordedEvent> eventQueue = this.eventQueue, int timeoutValue, TimeUnit timeoutUnit) {
+    private boolean expectOverflow(BlockingQueue<FileWatchEvent> eventQueue = this.eventQueue, int timeoutValue, TimeUnit timeoutUnit) {
         boolean overflow = false
         expectEvents(eventQueue, timeoutValue, timeoutUnit, { -> true }, { event ->
             if (event == null) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsOverflowTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsOverflowTest.groovy
@@ -102,15 +102,6 @@ class FileEventFunctionsOverflowTest extends AbstractFileEventFunctionsTest {
         waitForChangeEventLatency()
 
         then:
-        // We still have the notification in there about the first file
-        singleElementQueue.peek().type == CREATED
-        singleElementQueue.peek().path == firstFile.absolutePath
-
-        when:
-        // Wait for the next event to time out and be replaced with an overflow event
-        Thread.sleep(1000)
-
-        then:
         singleElementQueue.poll().type == OVERFLOWED
 
         then:

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -23,7 +23,6 @@ import spock.lang.Timeout
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.CREATED
@@ -89,7 +88,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
             def readyLatch = new CountDownLatch(numberOfThreads)
             def startModifyingLatch = new CountDownLatch(1)
             def inTheMiddleLatch = new CountDownLatch(numberOfThreads)
-            def watcher = startNewWatcher(new BlackHoleQueue<FileWatchEvent>())
+            def watcher = startNewWatcher()
             watchedDirectories.each { watchedDirectory ->
                 numberOfParallelWritersPerWatchedDirectory.times { index ->
                     executorService.submit({ ->
@@ -135,7 +134,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         List<File> watchedDirectories = createHierarchy(watchedDir, watchedDirectoryDepth)
 
         when:
-        def watcher = startNewWatcher(new BlackHoleQueue<FileWatchEvent>())
+        def watcher = startNewWatcher()
         watcher.startWatching(watchedDirectories as File[])
         waitForChangeEventLatency()
         assert rootDir.deleteDir()
@@ -155,7 +154,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         createHierarchy(watchedDir, watchedDirectoryDepth)
 
         when:
-        def watcher = startNewWatcher(new BlackHoleQueue<FileWatchEvent>())
+        def watcher = startNewWatcher()
         watcher.startWatching(watchedDir)
         waitForChangeEventLatency()
         assert watchedDir.deleteDir()
@@ -196,68 +195,6 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
             def dir = new File(rootDir, prefix + it)
             assert dir.mkdirs()
             return dir
-        }
-    }
-
-    private static class BlackHoleQueue<T> extends AbstractQueue<T> implements BlockingQueue<T> {
-
-        @Override
-        Iterator<T> iterator() {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        int size() {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        void put(T t) throws InterruptedException {
-        }
-
-        @Override
-        boolean offer(T t, long timeout, TimeUnit unit) throws InterruptedException {
-            return true
-        }
-
-        @Override
-        T take() throws InterruptedException {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        T poll(long timeout, TimeUnit unit) throws InterruptedException {
-            return null
-        }
-
-        @Override
-        int remainingCapacity() {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        int drainTo(Collection<? super T> c) {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        int drainTo(Collection<? super T> c, int maxElements) {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        boolean offer(T t) {
-            return true
-        }
-
-        @Override
-        T poll() {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        T peek() {
-            throw new UnsupportedOperationException()
         }
     }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -100,12 +100,12 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
                         readyLatch.countDown()
                         startModifyingLatch.await()
                         fileToChange.createNewFile()
-                        200.times { modifyIndex ->
+                        100.times { modifyIndex ->
                             fileToChange << "Change: $modifyIndex\n"
                             changeCount.incrementAndGet()
                         }
                         inTheMiddleLatch.countDown()
-                        300.times { modifyIndex ->
+                        400.times { modifyIndex ->
                             fileToChange << "Another change: $modifyIndex\n"
                             changeCount.incrementAndGet()
                         }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/SymlinkFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/SymlinkFileEventFunctionsTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Ignore
 import spock.lang.Requires
 
 import static java.nio.file.Files.createSymbolicLink
-import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.MODIFIED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.Type.MODIFIED
 
 @Requires({ Platform.current().macOs || Platform.current().linux || Platform.current().windows })
 class SymlinkFileEventFunctionsTest extends AbstractFileEventFunctionsTest {


### PR DESCRIPTION
This has a number of benefits:

1) it simplifies the code somewhat as there is no need to handle exceptions in user code on the native side,
2) ~~it simplifies test code a lot, as we don't need to handle async events,~~ (this part has been extracted into #160)
3) since the native thread is now free of user code execution, it is impossible for user code to try and run a command from this thread, preventing hard-to-debug hangs.
4) we can detect overflows to the event queue and change them into an overflow event