### PR TITLE
Fix closing empty watchpoint on macOS

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -205,7 +205,7 @@ void Server::registerPath(const u16string& path) {
 
 void Server::unregisterPath(const u16string& path) {
     if (watchPoints.erase(path) == 0) {
-        logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(WARNING, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
     }
 }
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -203,10 +203,12 @@ void Server::registerPath(const u16string& path) {
         forward_as_tuple(this, threadLoop, path, latencyInMillis));
 }
 
-void Server::unregisterPath(const u16string& path) {
+bool Server::unregisterPath(const u16string& path) {
     if (watchPoints.erase(path) == 0) {
-        logToJava(WARNING, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(INFO, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        return false;
     }
+    return true;
 }
 
 JNIEXPORT jobject JNICALL

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -89,9 +89,11 @@ Server::Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis)
 }
 
 Server::~Server() {
-    vector<u16string> paths(watchPoints.size());
-    for (auto& watchPoint : watchPoints) {
-        paths.push_back(watchPoint.first);
+    vector<u16string> paths;
+    paths.reserve(watchPoints.size());
+    for (auto& it : watchPoints) {
+        auto& path = it.first;
+        paths.push_back(path);
     }
     executeOnThread(shared_ptr<Command>(new UnregisterPathsCommand(paths)));
     executeOnThread(shared_ptr<Command>(new TerminateCommand()));

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -201,7 +201,7 @@ void Server::registerPath(const u16string& path) {
         forward_as_tuple(this, threadLoop, path, latencyInMillis));
 }
 
-void Server::unregisterPath(const u16string path) {
+void Server::unregisterPath(const u16string& path) {
     if (watchPoints.erase(path) == 0) {
         logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
     }

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -257,11 +257,11 @@ void Server::registerPath(const u16string& path) {
     watchRoots[watchPoint.watchDescriptor] = path;
 }
 
-void Server::unregisterPath(const u16string& path) {
+bool Server::unregisterPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it == watchPoints.end() || it->second.status == FINISHED) {
-        logToJava(WARNING, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
-        return;
+        logToJava(INFO, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        return false;
     }
     auto& watchPoint = it->second;
     if (watchPoint.cancel()) {
@@ -273,6 +273,7 @@ void Server::unregisterPath(const u16string& path) {
         watchRoots.erase(watchPoint.watchDescriptor);
         watchPoints.erase(path);
     }
+    return true;
 }
 
 JNIEXPORT jobject JNICALL

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -260,7 +260,7 @@ void Server::registerPath(const u16string& path) {
 void Server::unregisterPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it == watchPoints.end() || it->second.status == FINISHED) {
-        logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(WARNING, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
     auto& watchPoint = it->second;

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -257,7 +257,7 @@ void Server::registerPath(const u16string& path) {
     watchRoots[watchPoint.watchDescriptor] = path;
 }
 
-void Server::unregisterPath(const u16string path) {
+void Server::unregisterPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it == watchPoints.end() || it->second.status == FINISHED) {
         logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -361,7 +361,7 @@ void Server::unregisterPath(const u16string& path) {
     u16string longPath = path;
     convertToLongPathIfNeeded(longPath);
     if (watchPoints.erase(longPath) == 0) {
-        logToJava(FINE, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(WARNING, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
         return;
     }
 }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -357,7 +357,7 @@ void Server::registerPath(const u16string& path) {
         forward_as_tuple(this, longPath));
 }
 
-void Server::unregisterPath(const u16string path) {
+void Server::unregisterPath(const u16string& path) {
     u16string longPath = path;
     convertToLongPathIfNeeded(longPath);
     if (watchPoints.erase(longPath) == 0) {

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -357,13 +357,14 @@ void Server::registerPath(const u16string& path) {
         forward_as_tuple(this, longPath));
 }
 
-void Server::unregisterPath(const u16string& path) {
+bool Server::unregisterPath(const u16string& path) {
     u16string longPath = path;
     convertToLongPathIfNeeded(longPath);
     if (watchPoints.erase(longPath) == 0) {
-        logToJava(WARNING, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
-        return;
+        logToJava(INFO, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        return false;
     }
+    return true;
 }
 
 //

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -35,7 +35,7 @@ public:
     ~Server();
 
     void registerPath(const u16string& path) override;
-    void unregisterPath(const u16string& path) override;
+    bool unregisterPath(const u16string& path) override;
     void terminate() override;
 
     // TODO This should be private

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -35,7 +35,7 @@ public:
     ~Server();
 
     void registerPath(const u16string& path) override;
-    void unregisterPath(const u16string path) override;
+    void unregisterPath(const u16string& path) override;
     void terminate() override;
 
     // TODO This should be private

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -122,7 +122,7 @@ public:
 
 protected:
     virtual void registerPath(const u16string& path) = 0;
-    virtual void unregisterPath(const u16string path) = 0;
+    virtual void unregisterPath(const u16string& path) = 0;
 
     void reportChange(JNIEnv* env, int type, const u16string& path);
     void reportError(JNIEnv* env, const exception& ex);

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -52,7 +52,7 @@ public:
     ~Server();
 
     void registerPath(const u16string& path) override;
-    void unregisterPath(const u16string& path) override;
+    bool unregisterPath(const u16string& path) override;
 
 protected:
     void runLoop(function<void(exception_ptr)> notifyStarted) override;

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -52,7 +52,7 @@ public:
     ~Server();
 
     void registerPath(const u16string& path) override;
-    void unregisterPath(const u16string path) override;
+    void unregisterPath(const u16string& path) override;
 
 protected:
     void runLoop(function<void(exception_ptr)> notifyStarted) override;

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -65,7 +65,7 @@ public:
     ~Server();
 
     void registerPath(const u16string& path) override;
-    void unregisterPath(const u16string path) override;
+    void unregisterPath(const u16string& path) override;
     void terminate() override;
 
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -65,7 +65,7 @@ public:
     ~Server();
 
     void registerPath(const u16string& path) override;
-    void unregisterPath(const u16string& path) override;
+    bool unregisterPath(const u16string& path) override;
     void terminate() override;
 
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);

--- a/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 public interface FileWatcher extends Closeable {
     void startWatching(Collection<File> paths);
 
-    void stopWatching(Collection<File> paths);
+    boolean stopWatching(Collection<File> paths);
 
     /**
      * Stops watching and releases any native resources.

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -68,14 +68,14 @@ public class AbstractFileEventFunctions implements NativeIntegration {
         private native void startWatching0(Object server, String[] absolutePaths);
 
         @Override
-        public void stopWatching(Collection<File> paths) {
+        public boolean stopWatching(Collection<File> paths) {
             if (server == null) {
                 throw new IllegalStateException("Watcher already closed");
             }
-            stopWatching0(server, toAbsolutePaths(paths));
+            return stopWatching0(server, toAbsolutePaths(paths));
         }
 
-        private native void stopWatching0(Object server, String[] absolutePaths);
+        private native boolean stopWatching0(Object server, String[] absolutePaths);
 
         private static String[] toAbsolutePaths(Collection<File> files) {
             String[] paths = new String[files.size()];

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -61,7 +61,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
     TestFileWatcher watcher
     List<Throwable> uncaughtFailureOnThread
 
-    private boolean warningsIgnoredInLog
+    private List<String> expectedWarningsInLog
 
     // We could do this with @Delegate, but Groovy doesn't let us :(
     private FileWatcherFixture watcherFixture
@@ -73,6 +73,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         rootDir = new File(testDir, "root")
         assert rootDir.mkdirs()
         uncaughtFailureOnThread = []
+        expectedWarningsInLog = []
     }
 
     def cleanup() {
@@ -84,16 +85,15 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         def uncaughtExceptionCount = uncaughtFailureOnThread.size()
         assert uncaughtExceptionCount == 0
         LOGGER.info("<<< Finished '${testName.methodName}'")
-        if (!warningsIgnoredInLog) {
-            Collection<String> errorLogMessages = logging.messages
-                .findAll { message, level -> level.intValue() >= Level.WARNING.intValue() }
-                .keySet()
-            assert errorLogMessages.empty
-        }
+        Collection<String> unexpectedWarningsInLog = logging.messages
+            .findAll { message, level -> level.intValue() >= Level.WARNING.intValue() }
+            .keySet()
+        unexpectedWarningsInLog.removeAll(expectedWarningsInLog)
+        assert unexpectedWarningsInLog.empty
     }
 
-    void ignoreWarningsInLog() {
-        this.warningsIgnoredInLog = true
+    void expectWarningInLog(String message) {
+        expectedWarningsInLog << message
     }
 
     enum FileWatcherFixture {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -94,8 +94,11 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         unexpectedWarningsInLog.removeIf { message ->
             remainingExpectedWarningsInLog.removeIf { it.matcher(message).matches() }
         }
-        assert unexpectedWarningsInLog.empty
-        assert remainingExpectedWarningsInLog.empty
+        unexpectedWarningsInLog.each { System.err.println("Unexpected warning/error log message: $it")}
+        remainingExpectedWarningsInLog.each { System.err.println("Unmatched  warning/error log message: $it")}
+        def noUnexpectedWarningsInLog = unexpectedWarningsInLog.empty
+        def noMissingWarningsInLog = remainingExpectedWarningsInLog.empty
+        assert noUnexpectedWarningsInLog && noMissingWarningsInLog
     }
 
     void expectWarningInLog(String message) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -36,6 +36,7 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.logging.Level
 import java.util.logging.Logger
 import java.util.regex.Pattern
 
@@ -60,6 +61,8 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
     TestFileWatcher watcher
     List<Throwable> uncaughtFailureOnThread
 
+    private boolean warningsIgnoredInLog
+
     // We could do this with @Delegate, but Groovy doesn't let us :(
     private FileWatcherFixture watcherFixture
 
@@ -81,6 +84,16 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         def uncaughtExceptionCount = uncaughtFailureOnThread.size()
         assert uncaughtExceptionCount == 0
         LOGGER.info("<<< Finished '${testName.methodName}'")
+        if (!warningsIgnoredInLog) {
+            Collection<String> errorLogMessages = logging.messages
+                .findAll { message, level -> level.intValue() >= Level.WARNING.intValue() }
+                .keySet()
+            assert errorLogMessages.empty
+        }
+    }
+
+    void ignoreWarningsInLog() {
+        this.warningsIgnoredInLog = true
     }
 
     enum FileWatcherFixture {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -286,6 +286,8 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         then:
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/
+
+        expectWarningInLog(/Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/)
     }
 
     // Apparently on macOS we can watch files
@@ -301,6 +303,8 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         then:
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}/
+
+        expectWarningInLog(/Caught exception: Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}/)
     }
 
     def "fails when watching directory twice"() {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -305,7 +305,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
     def "fails when watching directory twice"() {
         given:
-        ignoreWarningsInLog()
         startWatcher(rootDir)
 
         when:
@@ -314,11 +313,12 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         then:
         def ex = thrown NativeException
         ex.message == "Already watching path: ${rootDir.absolutePath}"
+
+        expectWarningInLog("Caught exception: Already watching path: ${rootDir.absolutePath}")
     }
 
     def "can un-watch path that was not watched"() {
         given:
-        ignoreWarningsInLog()
         startWatcher()
 
         when:
@@ -326,11 +326,12 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         noExceptionThrown()
+
+        expectWarningInLog("Path is not watched: ${rootDir.absolutePath}")
     }
 
     def "can un-watch watched directory twice"() {
         given:
-        ignoreWarningsInLog()
         startWatcher(rootDir)
         watcher.stopWatching(rootDir)
 
@@ -339,6 +340,8 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         noExceptionThrown()
+
+        expectWarningInLog("Path is not watched: ${rootDir.absolutePath}")
     }
 
     def "does not receive events after directory is unwatched"() {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -30,6 +30,9 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import java.util.regex.Pattern
 
+import static java.util.logging.Level.INFO
+import static java.util.logging.Level.SEVERE
+import static java.util.logging.Level.WARNING
 import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.CREATED
 import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.INVALIDATE
 import static net.rubygrapefruit.platform.file.FileWatcherCallback.Type.MODIFIED
@@ -287,7 +290,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/
 
-        expectWarningInLog(Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
+        expectLogMessage(SEVERE, Pattern.compile(SEVERE, "Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
     }
 
     // Apparently on macOS we can watch files
@@ -304,7 +307,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}/
 
-        expectWarningInLog(Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}"))
+        expectLogMessage(SEVERE, Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}"))
     }
 
     def "fails when watching directory twice"() {
@@ -318,20 +321,17 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def ex = thrown NativeException
         ex.message == "Already watching path: ${rootDir.absolutePath}"
 
-        expectWarningInLog("Caught exception: Already watching path: ${rootDir.absolutePath}")
+        expectLogMessage(SEVERE, "Caught exception: Already watching path: ${rootDir.absolutePath}")
     }
 
     def "can un-watch path that was not watched"() {
         given:
         startWatcher()
 
-        when:
-        watcher.stopWatching(rootDir)
+        expect:
+        !watcher.stopWatching(rootDir)
 
-        then:
-        noExceptionThrown()
-
-        expectWarningInLog("Path is not watched: ${rootDir.absolutePath}")
+        expectLogMessage(INFO, "Path is not watched: ${rootDir.absolutePath}")
     }
 
     def "can un-watch watched directory twice"() {
@@ -339,19 +339,18 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         startWatcher(rootDir)
         watcher.stopWatching(rootDir)
 
-        when:
-        watcher.stopWatching(rootDir)
+        expect:
+        !watcher.stopWatching(rootDir)
 
-        then:
-        noExceptionThrown()
-
-        expectWarningInLog("Path is not watched: ${rootDir.absolutePath}")
+        expectLogMessage(INFO, "Path is not watched: ${rootDir.absolutePath}")
     }
 
     def "does not receive events after directory is unwatched"() {
         given:
         def file = new File(rootDir, "first.txt")
         startWatcher(rootDir)
+
+        expect:
         watcher.stopWatching(rootDir)
 
         when:
@@ -639,7 +638,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         when:
         stopWatcher()
         logging.clear()
-        nativeLogger.level = Level.WARNING
+        nativeLogger.level = WARNING
         ensureLogLevelInvalidated(service)
         startWatcher()
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -287,7 +287,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/
 
-        expectWarningInLog(/Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/)
+        expectWarningInLog(Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
     }
 
     // Apparently on macOS we can watch files
@@ -304,7 +304,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}/
 
-        expectWarningInLog(/Caught exception: Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}/)
+        expectWarningInLog(Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}"))
     }
 
     def "fails when watching directory twice"() {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -290,7 +290,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def ex = thrown NativeException
         ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/
 
-        expectLogMessage(SEVERE, Pattern.compile(SEVERE, "Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
+        expectLogMessage(SEVERE, Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
     }
 
     // Apparently on macOS we can watch files

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -305,6 +305,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
     def "fails when watching directory twice"() {
         given:
+        ignoreWarningsInLog()
         startWatcher(rootDir)
 
         when:
@@ -317,6 +318,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
     def "can un-watch path that was not watched"() {
         given:
+        ignoreWarningsInLog()
         startWatcher()
 
         when:
@@ -328,6 +330,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
     def "can un-watch watched directory twice"() {
         given:
+        ignoreWarningsInLog()
         startWatcher(rootDir)
         watcher.stopWatching(rootDir)
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -45,7 +45,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def createdFile = new File(rootDir, "created.txt")
         startWatcher(rootDir)
         100.times {
-            watcher.stopWatching(rootDir)
+            assert watcher.stopWatching(rootDir)
             watcher.startWatching(rootDir)
         }
 
@@ -65,7 +65,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         when:
         100.times { iteration ->
             watcher.startWatching(watchedDirs)
-            watcher.stopWatching(watchedDirs)
+            assert watcher.stopWatching(watchedDirs)
         }
 
         then:


### PR DESCRIPTION
The macOS native watcher emits `Path not watched:` messages upon shutdown. This is caused by incorrectly allocating a `std::vector`. This PR fixes the allocation and reverts another attempted (but not working) workaround targeted at the same problem.