### PR TITLE
Decrease folder depth to make sure we don't get an overflow on Windows

### DIFF
--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -15,8 +15,6 @@
 
 using namespace std;
 
-#define EVENT_BUFFER_SIZE (16 * 1024)
-
 #define CREATE_SHARE (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
 #define CREATE_FLAGS (FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED)
 
@@ -38,7 +36,7 @@ enum ListenResult {
 
 class WatchPoint {
 public:
-    WatchPoint(Server* server, const u16string& path);
+    WatchPoint(Server* server, size_t bufferSize, const u16string& path);
     ~WatchPoint();
 
     ListenResult listen();
@@ -61,7 +59,7 @@ private:
 
 class Server : public AbstractServer {
 public:
-    Server(JNIEnv* env, jobject watcherCallback);
+    Server(JNIEnv* env, size_t bufferSize, jobject watcherCallback);
     ~Server();
 
     void registerPath(const u16string& path) override;
@@ -77,6 +75,7 @@ protected:
 private:
     void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info);
 
+    const size_t bufferSize;
     unordered_map<u16string, WatchPoint> watchPoints;
     bool terminated = false;
 };

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -51,9 +51,9 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
      */
     // TODO What about symlinks?
     // TODO What about SUBST drives?
-    public FileWatcher startWatcher(FileWatcherCallback callback) {
-        return startWatcher0(new NativeFileWatcherCallback(callback));
+    public FileWatcher startWatcher(int bufferSize, FileWatcherCallback callback) {
+        return startWatcher0(bufferSize, new NativeFileWatcherCallback(callback));
     }
 
-    private static native FileWatcher startWatcher0(NativeFileWatcherCallback callback);
+    private static native FileWatcher startWatcher0(int bufferSize, NativeFileWatcherCallback callback);
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -177,7 +177,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
 
             @Override
             FileWatcher startNewWatcherInternal(FileWatcherCallback callback) {
-                service.startWatcher(callback)
+                service.startWatcher(64 * 1024, callback)
             }
 
             @Override

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -177,10 +177,14 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
 
             @Override
             FileWatcher startNewWatcherInternal(FileWatcherCallback callback, boolean preventOverflow) {
-                int bufferSize = preventOverflow
-                    ? 1024 * 1024
-                    : 16 * 1024
-                service.startWatcher(bufferSize, callback)
+                int bufferSizeInKb
+                if (preventOverflow) {
+                    bufferSizeInKb = 16384
+                    AbstractFileEventFunctionsTest.LOGGER.info("Using $bufferSizeInKb kByte buffer to prevent overflow events");
+                } else {
+                    bufferSizeInKb = 16
+                }
+                service.startWatcher(bufferSizeInKb * 1024, callback)
             }
 
             @Override

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -57,7 +57,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         expectEvents change(CREATED, createdFile)
     }
 
-    def "can stop and restart watching many directory many times"() {
+    def "can stop and restart watching many directories many times"() {
         given:
         File[] watchedDirs = createDirectoriesToWatch(100)
 
@@ -134,8 +134,6 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
     }
 
     @Requires({ !Platform.current().linux })
-    // TODO Fix overflow event on Windows
-    @IgnoreIf({ Platform.current().windows })
     def "can stop watching a deep hierarchy when it has been deleted"() {
         given:
         def watchedDirectoryDepth = 10

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -17,7 +17,6 @@
 package net.rubygrapefruit.platform.file
 
 import net.rubygrapefruit.platform.internal.Platform
-import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Timeout
 
@@ -151,6 +150,12 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         then:
         noExceptionThrown()
+    }
+
+    @Override
+    protected TestFileWatcher startNewWatcher(FileWatcherCallback callback) {
+        // Make sure we don't receive overflow events during these tests
+        return watcherFixture.startNewWatcherWithOverflowPrevention(callback)
     }
 
     private static List<File> createHierarchy(File root, int watchedDirectoryDepth, int branching = 2) {

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -152,11 +152,14 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def watchedDir = new File(rootDir, "watchedDir")
         assert watchedDir.mkdir()
         List<File> previousRoots = [watchedDir]
-        watchedDirectoryDepth.times { depth ->
+        int count = 1
+        (watchedDirectoryDepth - 1).times { depth ->
             previousRoots = previousRoots.collectMany { root ->
                 createSubdirs(root, 2)
             }
+            count += previousRoots.size()
         }
+        LOGGER.info "> Created $count directories"
 
         when:
         def watcher = startNewWatcher(newEventSinkCallback())

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -415,7 +415,7 @@ public class Main {
                 .startWatcher(callback);
         } else if (Platform.current().isWindows()) {
             watcher = Native.get(WindowsFileEventFunctions.class)
-                .startWatcher(callback);
+                .startWatcher(64 * 1024, callback);
         } else {
             throw new RuntimeException("Only Windows and macOS are supported for file watching");
         }


### PR DESCRIPTION
It seems that overflow arrives around 4000 events.

We currently generate 2^11 = 2048 directories, and deleting each produces 1 `REMOVED` and 0-2 `MODIFIED` events (depending on Windows' taste at the moment). The resulting number of events hovers around 4000 that seems to be some kind of limit.

By halving the size of the deleted hierarchy we can avoid the overflow.