### PR TITLE
Fix crash when catching exception from callback

### DIFF
--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -268,7 +268,7 @@ bool Server::unregisterPath(const u16string& path) {
         processQueues(0);
     }
     if (watchPoint.status != FINISHED) {
-        throw FileWatcherException("Could not cancel watch point %s", path);
+        throw FileWatcherException("Could not cancel watch point", path);
     } else {
         watchRoots.erase(watchPoint.watchDescriptor);
         watchPoints.erase(path);


### PR DESCRIPTION
Exceptions from the Java side with no message
caused the native code to crash.