### PR TITLE
Continue listening after overflow

### DIFF
--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -149,18 +149,16 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
             // Got a buffer overflow => current changes lost => send INVALIDATE on root
             logToJava(INFO, "Detected overflow for %s", utf16ToUtf8String(path).c_str());
             reportChange(env, FILE_EVENT_INVALIDATE, path);
-            watchPoint->status = FINISHED;
-            return;
-        }
-
-        int index = 0;
-        for (;;) {
-            FILE_NOTIFY_INFORMATION* current = (FILE_NOTIFY_INFORMATION*) &buffer[index];
-            handleEvent(env, path, current);
-            if (current->NextEntryOffset == 0) {
-                break;
+        } else {
+            int index = 0;
+            for (;;) {
+                FILE_NOTIFY_INFORMATION* current = (FILE_NOTIFY_INFORMATION*) &buffer[index];
+                handleEvent(env, path, current);
+                if (current->NextEntryOffset == 0) {
+                    break;
+                }
+                index += current->NextEntryOffset;
             }
-            index += current->NextEntryOffset;
         }
 
         switch (watchPoint->listen()) {


### PR DESCRIPTION
We should not stop listening to a `WatchPoint` when an overflow event is received. Instead we should continue delivering the events after invalidating the whole watched hierarchy.

This is as it should be on Linux and macOS already, we only need to change the behavior on Windows.