### PR TITLE
Use builder pattern to configure watcher

### DIFF
--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -8,7 +8,7 @@ import net.rubygrapefruit.platform.file.FileWatcherCallback;
 import java.io.File;
 import java.util.Collection;
 
-public class AbstractFileEventFunctions implements NativeIntegration {
+public abstract class AbstractFileEventFunctions implements NativeIntegration {
     public static String getVersion() {
         return getVersion0();
     }
@@ -24,6 +24,22 @@ public class AbstractFileEventFunctions implements NativeIntegration {
     }
 
     private native void invalidateLogLevelCache0();
+
+    public abstract static class AbstractWatcherBuilder {
+        protected final FileWatcherCallback callback;
+
+        public AbstractWatcherBuilder(FileWatcherCallback callback) {
+            this.callback = callback;
+        }
+
+        public abstract FileWatcher start();
+    }
+
+    /**
+     * Configures a new watcher using a builder. Call {@link AbstractWatcherBuilder#start()} to
+     * actually start the {@link FileWatcher}.
+     */
+    public abstract AbstractWatcherBuilder newWatcher(FileWatcherCallback callback);
 
     protected static class NativeFileWatcherCallback {
         private final FileWatcherCallback delegate;

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -32,6 +32,11 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
             this.callback = callback;
         }
 
+        /**
+         * Start the file watcher.
+         *
+         * @see FileWatcher#startWatching(Collection)
+         */
         public abstract FileWatcher start();
     }
 

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -19,21 +19,35 @@ package net.rubygrapefruit.platform.internal.jni;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.file.FileWatcherCallback;
 
+
+/**
+ * File watcher for Linux. Reports changes to the watched paths and their immediate children.
+ * Changes to deeper descendants are not reported.
+ *
+ * <h3>Remarks:</h3>
+ *
+ * <ul>
+ *     <li>Events arrive from a single background thread unique to the {@link FileWatcher}.
+ *     Calling methods from the {@link FileWatcher} inside the callback method is undefined
+ *     behavior and can lead to a deadlock.</li>
+ * </ul>
+ */
 public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
 
-    /**
-     * Start watching the given directories.
-     *
-     * <h3>Remarks:</h3>
-     *
-     * <ul>
-     *     <li>Changes to descendants to the given paths are not reported.</li>
-     * 
-     *     <li>TBD</li>
-     * </ul>
-     */
-    public FileWatcher startWatcher(FileWatcherCallback callback) {
-        return startWatcher0(new NativeFileWatcherCallback(callback));
+    @Override
+    public WatcherBuilder newWatcher(FileWatcherCallback callback) {
+        return new WatcherBuilder(callback);
+    }
+
+    public static class WatcherBuilder extends AbstractWatcherBuilder {
+        WatcherBuilder(FileWatcherCallback callback) {
+            super(callback);
+        }
+
+        @Override
+        public FileWatcher start() {
+            return startWatcher0(new NativeFileWatcherCallback(callback));
+        }
     }
 
     private static native FileWatcher startWatcher0(NativeFileWatcherCallback callback);

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventFunctionsTest.groovy
@@ -138,10 +138,9 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             FileWatcher startNewWatcherInternal(FileWatcherCallback callback, boolean preventOverflow) {
                 // Avoid setup operations to be reported
                 waitForChangeEventLatency()
-                service.startWatcher(
-                    LATENCY_IN_MILLIS, TimeUnit.MILLISECONDS,
-                    callback
-                )
+                service.newWatcher(callback)
+                    .withLatency(LATENCY_IN_MILLIS, TimeUnit.MILLISECONDS)
+                    .start()
             }
 
             @Override
@@ -160,7 +159,8 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             FileWatcher startNewWatcherInternal(FileWatcherCallback callback, boolean preventOverflow) {
                 // Avoid setup operations to be reported
                 waitForChangeEventLatency()
-                service.startWatcher(callback)
+                service.newWatcher(callback)
+                    .start()
             }
 
             @Override
@@ -184,7 +184,9 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
                 } else {
                     bufferSizeInKb = 16
                 }
-                service.startWatcher(bufferSizeInKb * 1024, callback)
+                service.newWatcher(callback)
+                    .withBufferSize(bufferSizeInKb * 1024)
+                    .start()
             }
 
             @Override

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -53,7 +53,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class Main {
     public static void main(String[] args) throws IOException {
@@ -409,13 +408,16 @@ public class Main {
         FileWatcher watcher;
         if (Platform.current().isMacOs()) {
             watcher = Native.get(OsxFileEventFunctions.class)
-                .startWatcher(300, TimeUnit.MILLISECONDS, callback);
+                .newWatcher(callback)
+                .start();
         } else if (Platform.current().isLinux()) {
             watcher = Native.get(LinuxFileEventFunctions.class)
-                .startWatcher(callback);
+                .newWatcher(callback)
+                .start();
         } else if (Platform.current().isWindows()) {
             watcher = Native.get(WindowsFileEventFunctions.class)
-                .startWatcher(64 * 1024, callback);
+                .newWatcher(callback)
+                .start();
         } else {
             throw new RuntimeException("Only Windows and macOS are supported for file watching");
         }


### PR DESCRIPTION
This allows us to add more configuration options without breaking backwards compatibility.