### PR TITLE
Move thread handling to Java

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -100,7 +100,7 @@ void Server::executeRunLoop() {
     CFRunLoopRun();
 }
 
-void Server::terminateInternal() {
+void Server::terminateRunLoop() {
     watchPoints.clear();
     // TODO Should we stop the runloop before destructing all the watches now?
     CFRunLoopStop(threadLoop);

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -96,7 +96,7 @@ void Server::initializeRunLoop() {
     CFRunLoopAddSource(threadLoop, messageSource, kCFRunLoopDefaultMode);
 }
 
-void Server::executeRunLoop() {
+void Server::runLoop() {
     CFRunLoopRun();
 }
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -98,13 +98,14 @@ void Server::initializeRunLoop() {
 
 void Server::runLoop() {
     CFRunLoopRun();
+
+    unique_lock<mutex> lock(mutationMutex);
+    watchPoints.clear();
+    CFRelease(messageSource);
 }
 
 void Server::terminateRunLoop() {
-    watchPoints.clear();
-    // TODO Should we stop the runloop before destructing all the watches now?
     CFRunLoopStop(threadLoop);
-    CFRelease(messageSource);
 }
 
 static void handleEventsCallback(

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -122,9 +122,8 @@ bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
 }
 
 void AbstractServer::terminate() {
-    terminateRunLoop();
-
     unique_lock<mutex> terminationLock(terminationMutex);
+    terminateRunLoop();
     // TODO Parametrize this
     auto status = terminated.wait_for(terminationLock, THREAD_TIMEOUT);
     if (status == cv_status::timeout) {

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -113,7 +113,7 @@ bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
 
 void AbstractServer::terminate() {
     unique_lock<mutex> lock(mutationMutex);
-    terminateInternal();
+    terminateRunLoop();
 }
 
 JNIEXPORT void JNICALL

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -118,9 +118,7 @@ bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
 }
 
 void AbstractServer::terminate() {
-    unique_lock<mutex> lock(mutationMutex);
     terminateRunLoop();
-    mutationMutex.unlock();
 
     unique_lock<mutex> terminationLock(terminationMutex);
     // TODO Parametrize this

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -119,11 +119,14 @@ bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
 
 void AbstractServer::terminate() {
     unique_lock<mutex> lock(mutationMutex);
-    unique_lock<mutex> terminationLock(terminationMutex);
     terminateRunLoop();
+    mutationMutex.unlock();
+
+    unique_lock<mutex> terminationLock(terminationMutex);
+    // TODO Parametrize this
     auto status = terminated.wait_for(terminationLock, THREAD_TIMEOUT);
     if (status == cv_status::timeout) {
-        throw FileWatcherException("Starting thread timed out");
+        throw FileWatcherException("Termination timed out");
     }
 }
 

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -94,8 +94,12 @@ jobject wrapServer(JNIEnv* env, AbstractServer* server) {
     return env->NewDirectByteBuffer(server, sizeof(server));
 }
 
-void AbstractServer::executeRunLoop() {
-    runLoop();
+void AbstractServer::executeRunLoop(JNIEnv* env) {
+    try {
+        runLoop();
+    } catch (const exception& ex) {
+        rethrowAsJavaException(env, ex);
+    }
     unique_lock<mutex> terminationLock(terminationMutex);
     terminated.notify_all();
 }
@@ -142,7 +146,7 @@ JNIEXPORT void JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_executeRunLoop0(JNIEnv* env, jobject, jobject javaServer) {
     try {
         AbstractServer* server = getServer(env, javaServer);
-        server->executeRunLoop();
+        server->executeRunLoop(env);
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
     }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -186,8 +186,13 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
     }
 }
 
-JNIEXPORT void JNICALL Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_invalidateLogLevelCache0(JNIEnv*, jobject) {
-    logging->invalidateLogLevelCache();
+JNIEXPORT void JNICALL
+Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_invalidateLogLevelCache0(JNIEnv* env, jobject) {
+    try {
+        logging->invalidateLogLevelCache();
+    } catch (const exception& e) {
+        rethrowAsJavaException(env, e);
+    }
 }
 
 NativePlatformJniConstants::NativePlatformJniConstants(JavaVM* jvm)

--- a/src/file-events/cpp/jni_support.cpp
+++ b/src/file-events/cpp/jni_support.cpp
@@ -70,30 +70,6 @@ void JniSupport::rethrowJavaException(JNIEnv* env) {
     }
 }
 
-JniThreadAttacher::JniThreadAttacher(JavaVM* jvm, const char* name, bool daemon)
-    : JniSupport(jvm) {
-    JNIEnv* env;
-    JavaVMAttachArgs args = {
-        JNI_VERSION_1_6,            // version
-        const_cast<char*>(name),    // thread name
-        NULL                        // thread group
-    };
-    jint ret = daemon
-        ? jvm->AttachCurrentThreadAsDaemon((void**) &env, (void*) &args)
-        : jvm->AttachCurrentThread((void**) &env, (void*) &args);
-    if (ret != JNI_OK) {
-        cerr << "Failed to attach JNI to current thread: " << ret << endl;
-        throw runtime_error(string("Failed to attach JNI to current thread: ") + to_string(ret));
-    }
-}
-
-JniThreadAttacher::~JniThreadAttacher() {
-    jint ret = jvm->DetachCurrentThread();
-    if (ret != JNI_OK) {
-        cerr << "Failed to detach JNI from current thread: " << ret << endl;
-    }
-}
-
 BaseJniConstants::BaseJniConstants(JavaVM* jvm)
     : JniSupport(jvm)
     , classClass(getThreadEnv(), "java/lang/Class") {

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -127,6 +127,7 @@ void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
 }
 
 void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred) {
+    unique_lock<mutex> lock(mutationMutex);
     JNIEnv* env = getThreadEnv();
     const u16string& path = watchPoint->path;
 

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -264,31 +264,38 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
 Server::Server(JNIEnv* env, size_t bufferSize, jobject watcherCallback)
     : AbstractServer(env, watcherCallback)
     , bufferSize(bufferSize) {
-    startThread();
-    // TODO Error handling
-    SetThreadPriority(this->watcherThread.native_handle(), THREAD_PRIORITY_ABOVE_NORMAL);
 }
 
-void Server::terminate() {
-    terminated = true;
-}
-
-Server::~Server() {
-    executeOnThread(shared_ptr<Command>(new TerminateCommand()));
-
-    if (watcherThread.joinable()) {
-        watcherThread.join();
+void Server::initializeRunLoop() {
+    // TODO For some reason GetCurrentThread() returns a thread that doesn't accept APCs
+    threadHandle = OpenThread(
+        THREAD_ALL_ACCESS,
+        false,
+        GetCurrentThreadId()
+    );
+    if (threadHandle == NULL) {
+        throw FileWatcherException("Couldn't open current thread", GetLastError());
     }
 }
 
-void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
-    notifyStarted(nullptr);
+void Server::terminateRunLoop() {
+    executeOnRunLoop([this]() {
+        terminated = true;
+        return true;
+    });
+}
 
+Server::~Server() {
+    terminate();
+}
+
+void Server::runLoop() {
     while (!terminated) {
         SleepEx(INFINITE, true);
     }
 
     // We have received termination, cancel all watchers
+    unique_lock<mutex> lock(mutationMutex);
     logToJava(FINE, "Finished with run loop, now cancelling remaining watch points", NULL);
     int pendingWatchPoints = 0;
     for (auto& it : watchPoints) {
@@ -330,15 +337,51 @@ void Server::runLoop(function<void(exception_ptr)> notifyStarted) {
                 break;
         }
     }
+
+    CloseHandle(threadHandle);
 }
 
-static void CALLBACK processCommandsCallback(_In_ ULONG_PTR info) {
-    Server* server = (Server*) info;
-    server->processCommands();
+static void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info) {
+    Command* command = (Command*) info;
+    try {
+        command->result = command->function();
+    } catch (const exception&) {
+        command->failure = current_exception();
+    }
+    unique_lock<mutex> lock(command->server->executionMutex);
+    command->executed.notify_all();
 }
 
-void Server::processCommandsOnThread() {
-    QueueUserAPC(processCommandsCallback, watcherThread.native_handle(), (ULONG_PTR) this);
+bool Server::executeOnRunLoop(function<bool()> function) {
+    Command command;
+    command.function = function;
+    command.server = this;
+    DWORD ret = QueueUserAPC(executeOnRunLoopCallback, threadHandle, (ULONG_PTR) &command);
+    if (ret == 0) {
+        throw FileWatcherException("Received error while queuing APC", GetLastError());
+    }
+    unique_lock<mutex> lock(executionMutex);
+    auto status = command.executed.wait_for(lock, THREAD_TIMEOUT);
+    if (status == cv_status::timeout) {
+        throw FileWatcherException("Execution timed out");
+    } else if (command.failure) {
+        rethrow_exception(command.failure);
+    } else {
+        return command.result;
+    }
+}
+
+void Server::registerPaths(const vector<u16string>& paths) {
+    executeOnRunLoop([this, paths]() {
+        AbstractServer::registerPaths(paths);
+        return true;
+    });
+}
+
+bool Server::unregisterPaths(const vector<u16string>& paths) {
+    return executeOnRunLoop([this, paths]() {
+        return AbstractServer::unregisterPaths(paths);
+    });
 }
 
 void Server::registerPath(const u16string& path) {
@@ -372,9 +415,7 @@ bool Server::unregisterPath(const u16string& path) {
 
 JNIEXPORT jobject JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatcher0(JNIEnv* env, jclass target, jint bufferSize, jobject javaCallback) {
-    return wrapServer(env, [env, bufferSize, javaCallback]() {
-        return new Server(env, bufferSize, javaCallback);
-    });
+    return wrapServer(env, new Server(env, bufferSize, javaCallback));
 }
 
 #endif

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -357,11 +357,11 @@ bool Server::executeOnRunLoop(function<bool()> function) {
     Command command;
     command.function = function;
     command.server = this;
+    unique_lock<mutex> lock(executionMutex);
     DWORD ret = QueueUserAPC(executeOnRunLoopCallback, threadHandle, (ULONG_PTR) &command);
     if (ret == 0) {
         throw FileWatcherException("Received error while queuing APC", GetLastError());
     }
-    unique_lock<mutex> lock(executionMutex);
     auto status = command.executed.wait_for(lock, THREAD_TIMEOUT);
     if (status == cv_status::timeout) {
         throw FileWatcherException("Execution timed out");

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -342,6 +342,14 @@ void Server::runLoop() {
     CloseHandle(threadHandle);
 }
 
+struct Command {
+    Server* server;
+    function<bool()> function;
+    condition_variable executed;
+    bool result;
+    exception_ptr failure;
+};
+
 static void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info) {
     Command* command = (Command*) info;
     try {

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -240,7 +240,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMA
         }
     }
 
-    // logToJava(FINE, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
+    logToJava(FINE, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
 
     jint type;
     if (info->Action == FILE_ACTION_ADDED || info->Action == FILE_ACTION_RENAMED_NEW_NAME) {

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -34,10 +34,6 @@ public:
     Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis);
     ~Server();
 
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
-    void terminate() override;
-
     // TODO This should be private
     void handleEvents(
         size_t numEvents,
@@ -45,8 +41,12 @@ public:
         const FSEventStreamEventFlags eventFlags[]);
 
 protected:
-    void runLoop(function<void(exception_ptr)> notifyStarted) override;
-    void processCommandsOnThread() override;
+    void initializeRunLoop() override;
+    void executeRunLoop() override;
+
+    void registerPath(const u16string& path) override;
+    bool unregisterPath(const u16string& path) override;
+    void terminateInternal() override;
 
 private:
     void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -46,7 +46,7 @@ protected:
 
     void registerPath(const u16string& path) override;
     bool unregisterPath(const u16string& path) override;
-    void terminateInternal() override;
+    void terminateRunLoop() override;
 
 private:
     void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -42,7 +42,7 @@ public:
 
 protected:
     void initializeRunLoop() override;
-    void executeRunLoop() override;
+    void runLoop() override;
 
     void registerPath(const u16string& path) override;
     bool unregisterPath(const u16string& path) override;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -69,7 +69,7 @@ public:
     virtual ~AbstractServer();
 
     virtual void initializeRunLoop() = 0;
-    virtual void executeRunLoop() = 0;
+    void executeRunLoop();
 
     /**
      * Registers new watch point with the server for the given paths.
@@ -87,6 +87,7 @@ public:
     void terminate();
 
 protected:
+    virtual void runLoop() = 0;
     virtual void registerPath(const u16string& path) = 0;
     virtual bool unregisterPath(const u16string& path) = 0;
     virtual void terminateRunLoop() = 0;
@@ -95,6 +96,8 @@ protected:
     void reportError(JNIEnv* env, const exception& ex);
 
     mutex mutationMutex;
+    mutex terminationMutex;
+    condition_variable terminated;
 
 private:
     JniGlobalRef<jobject> watcherCallback;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <exception>
-#include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -74,12 +73,12 @@ public:
     /**
      * Registers new watch point with the server for the given paths.
      */
-    void registerPaths(const vector<u16string>& paths);
+    virtual void registerPaths(const vector<u16string>& paths);
 
     /**
      * Unregisters watch points with the server for the given paths.
      */
-    bool unregisterPaths(const vector<u16string>& paths);
+    virtual bool unregisterPaths(const vector<u16string>& paths);
 
     /**
      * Terminates server.

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -68,7 +68,7 @@ public:
     virtual ~AbstractServer();
 
     virtual void initializeRunLoop() = 0;
-    void executeRunLoop();
+    void executeRunLoop(JNIEnv* env);
 
     /**
      * Registers new watch point with the server for the given paths.

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -63,129 +63,43 @@ enum WatchPointStatus {
 
 class AbstractServer;
 
-class Command {
-public:
-    Command() {};
-    virtual ~Command() {};
-
-    void execute(AbstractServer* server) {
-        try {
-            success = perform(server);
-        } catch (const exception&) {
-            failure = current_exception();
-        }
-        executed.notify_all();
-    }
-
-    virtual bool perform(AbstractServer* server) = 0;
-
-    condition_variable executed;
-    bool success;
-    exception_ptr failure;
-};
-
 class AbstractServer : public JniSupport {
 public:
     AbstractServer(JNIEnv* env, jobject watcherCallback);
     virtual ~AbstractServer();
 
-    /**
-     * Execute command on processing thread sybnchronously.
-     *
-     * Returns wether the exeuction of the command had an effect.
-     */
-    bool executeOnThread(shared_ptr<Command> command);
-
-    //
-    // Methods running on the processing thread
-    //
-
-    /**
-     * Processes queued commands, should be called from processing thread.
-     */
-    void processCommands();
+    virtual void initializeRunLoop() = 0;
+    virtual void executeRunLoop() = 0;
 
     /**
      * Registers new watch point with the server for the given paths.
-     * Runs on processing thread.
      */
     void registerPaths(const vector<u16string>& paths);
 
     /**
      * Unregisters watch points with the server for the given paths.
-     * Runs on processing thread.
      */
     bool unregisterPaths(const vector<u16string>& paths);
 
     /**
      * Terminates server.
-     * Runs on processing thread.
      */
-    virtual void terminate() = 0;
+    void terminate();
 
 protected:
     virtual void registerPath(const u16string& path) = 0;
     virtual bool unregisterPath(const u16string& path) = 0;
+    virtual void terminateInternal() = 0;
 
     void reportChange(JNIEnv* env, int type, const u16string& path);
     void reportError(JNIEnv* env, const exception& ex);
 
-    void startThread();
-    virtual void runLoop(function<void(exception_ptr)> notifyStarted) = 0;
-    virtual void processCommandsOnThread() = 0;
-
-    thread watcherThread;
+    mutex mutationMutex;
 
 private:
-    void run();
-
-    mutex watcherThreadMutex;
-    condition_variable watcherThreadStarted;
-    exception_ptr initException;
-
-    mutex mtxCommands;
-    deque<shared_ptr<Command>> commands;
-
     JniGlobalRef<jobject> watcherCallback;
     jmethodID watcherCallbackMethod;
     jmethodID watcherReportErrorMethod;
-};
-
-class RegisterPathsCommand : public Command {
-public:
-    RegisterPathsCommand(const vector<u16string>& paths)
-        : paths(paths) {
-    }
-
-    bool perform(AbstractServer* server) override {
-        server->registerPaths(paths);
-        return true;
-    }
-
-private:
-    const vector<u16string> paths;
-};
-
-class UnregisterPathsCommand : public Command {
-public:
-    UnregisterPathsCommand(const vector<u16string>& paths)
-        : paths(paths) {
-    }
-
-    bool perform(AbstractServer* server) override {
-        return server->unregisterPaths(paths);
-    }
-
-private:
-    const vector<u16string> paths;
-};
-
-class TerminateCommand : public Command {
-public:
-    bool perform(AbstractServer* server) override {
-        server->terminate();
-        return true;
-    }
 };
 
 class NativePlatformJniConstants : public JniSupport {
@@ -193,10 +107,8 @@ public:
     NativePlatformJniConstants(JavaVM* jvm);
 
     const JClass nativeExceptionClass;
-    const JClass nativeFileWatcherClass;
 };
 
 extern NativePlatformJniConstants* nativePlatformJniConstants;
 
-// TODO Use a template for the server type?
-jobject wrapServer(JNIEnv* env, function<void*()> serverStarter);
+jobject wrapServer(JNIEnv* env, AbstractServer* server);

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -89,7 +89,7 @@ public:
 protected:
     virtual void registerPath(const u16string& path) = 0;
     virtual bool unregisterPath(const u16string& path) = 0;
-    virtual void terminateInternal() = 0;
+    virtual void terminateRunLoop() = 0;
 
     void reportChange(JNIEnv* env, int type, const u16string& path);
     void reportError(JNIEnv* env, const exception& ex);

--- a/src/file-events/headers/jni_support.h
+++ b/src/file-events/headers/jni_support.h
@@ -60,15 +60,6 @@ public:
     }
 };
 
-/**
- * Attach a native thread to JNI.
- */
-class JniThreadAttacher : public JniSupport {
-public:
-    JniThreadAttacher(JavaVM* jvm, const char* name, bool daemon);
-    ~JniThreadAttacher();
-};
-
 class BaseJniConstants : public JniSupport {
 public:
     BaseJniConstants(JavaVM* jvm);

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -22,9 +22,9 @@ struct Inotify {
     const int fd;
 };
 
-struct Event {
-    Event();
-    ~Event();
+struct TerminateEvent {
+    TerminateEvent();
+    ~TerminateEvent();
 
     void trigger() const;
     void consume() const;
@@ -52,13 +52,12 @@ public:
     Server(JNIEnv* env, jobject watcherCallback);
     ~Server();
 
+protected:
+    void initializeRunLoop() override;
+    void runLoop() override;
     void registerPath(const u16string& path) override;
     bool unregisterPath(const u16string& path) override;
-
-protected:
-    void runLoop(function<void(exception_ptr)> notifyStarted) override;
-    void processCommandsOnThread() override;
-    void terminate() override;
+    void terminateRunLoop() override;
 
 private:
     void processQueues(int timeout);
@@ -69,7 +68,7 @@ private:
     unordered_map<int, u16string> watchRoots;
     unordered_set<int> recentlyRemovedWatchPoints;
     const shared_ptr<Inotify> inotify;
-    const Event processCommandsEvent;
+    const TerminateEvent terminateEvent;
     bool terminated = false;
     vector<uint8_t> buffer;
 };

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -58,14 +58,6 @@ private:
     friend static void CALLBACK handleEventCallback(DWORD errorCode, DWORD bytesTransferred, LPOVERLAPPED overlapped);
 };
 
-struct Command {
-    Server* server;
-    function<bool()> function;
-    condition_variable executed;
-    bool result;
-    exception_ptr failure;
-};
-
 class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, size_t bufferSize, jobject watcherCallback);

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -45,10 +45,10 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
         }
 
         @Override
-        public FileWatcher start() {
-            return startWatcher0(new NativeFileWatcherCallback(callback));
+        public FileWatcher start() throws InterruptedException {
+            return new NativeFileWatcher(startWatcher0(new NativeFileWatcherCallback(callback)));
         }
     }
 
-    private static native FileWatcher startWatcher0(NativeFileWatcherCallback callback);
+    private static native Object startWatcher0(NativeFileWatcherCallback callback);
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -69,10 +69,10 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
         }
 
         @Override
-        public FileWatcher start() {
-            return startWatcher0(latencyInMillis, new NativeFileWatcherCallback(callback));
+        public FileWatcher start() throws InterruptedException {
+            return new NativeFileWatcher(startWatcher0(latencyInMillis, new NativeFileWatcherCallback(callback)));
         }
     }
 
-    private static native FileWatcher startWatcher0(long latencyInMillis, NativeFileWatcherCallback callback);
+    private static native Object startWatcher0(long latencyInMillis, NativeFileWatcherCallback callback);
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -67,10 +67,10 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
         }
 
         @Override
-        public FileWatcher start() {
-            return startWatcher0(bufferSize, new NativeFileWatcherCallback(callback));
+        public FileWatcher start() throws InterruptedException {
+            return new NativeFileWatcher(startWatcher0(bufferSize, new NativeFileWatcherCallback(callback)));
         }
     }
 
-    private static native FileWatcher startWatcher0(int bufferSize, NativeFileWatcherCallback callback);
+    private static native Object startWatcher0(int bufferSize, NativeFileWatcherCallback callback);
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -725,12 +725,16 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         given:
         def nativeLogger = Logger.getLogger(NativeLogger.name)
         def originalLevel = nativeLogger.level
+        def fileChanged = new File(rootDir, "changed.txt")
+        fileChanged.createNewFile()
 
         when:
         logging.clear()
         nativeLogger.level = Level.FINEST
         ensureLogLevelInvalidated(service)
-        startWatcher()
+        startWatcher(rootDir)
+        fileChanged << "changed"
+        waitForChangeEventLatency()
 
         then:
         logging.messages.values().any { it == Level.FINE }
@@ -741,6 +745,8 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         nativeLogger.level = WARNING
         ensureLogLevelInvalidated(service)
         startWatcher()
+        fileChanged << "changed again"
+        waitForChangeEventLatency()
 
         then:
         !logging.messages.values().any { it == Level.FINE }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -551,8 +551,8 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         watcher.close()
 
         then:
-        def ex = thrown NativeException
-        ex.message == "Closed already"
+        def ex = thrown IllegalStateException
+        ex.message == "Watcher already closed"
     }
 
     def "can be used multiple times"() {

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -55,7 +55,7 @@ import java.util.Date;
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         OptionParser optionParser = new OptionParser();
         optionParser.accepts("cache-dir", "The directory to cache native libraries in").withRequiredArg();
         optionParser.accepts("ansi", "Force the use of ANSI escape sequences for terminal output");
@@ -372,7 +372,7 @@ public class Main {
         System.out.println();
     }
 
-    private static void watch(String path) {
+    private static void watch(String path) throws InterruptedException {
         FileWatcher watcher = createWatcher(path, new FileWatcherCallback() {
             @Override
             public void pathChanged(Type type, String changedPath) {
@@ -404,7 +404,7 @@ public class Main {
         System.out.println("Done");
     }
 
-    private static FileWatcher createWatcher(String path, FileWatcherCallback callback) {
+    private static FileWatcher createWatcher(String path, FileWatcherCallback callback) throws InterruptedException {
         FileWatcher watcher;
         if (Platform.current().isMacOs()) {
             watcher = Native.get(OsxFileEventFunctions.class)


### PR DESCRIPTION
Instead of starting and handling threads in C++, we now set up the thread in Java. This allows for a number of simplifications in the native code and gives us all the Java tools for handling concurrency.