### PR TITLE
Simplify termination

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -87,10 +87,6 @@ Server::Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis)
     );
 }
 
-Server::~Server() {
-    terminate();
-}
-
 void Server::initializeRunLoop() {
     threadLoop = CFRunLoopGetCurrent();
     CFRunLoopAddSource(threadLoop, messageSource, kCFRunLoopDefaultMode);

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -180,6 +180,7 @@ JNIEXPORT void JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_close0(JNIEnv* env, jobject, jobject javaServer) {
     try {
         AbstractServer* server = getServer(env, javaServer);
+        server->terminate();
         delete server;
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -75,10 +75,6 @@ void Server::terminateRunLoop() {
     terminateEvent.trigger();
 }
 
-Server::~Server() {
-    terminate();
-}
-
 void Server::initializeRunLoop() {
 }
 

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -286,10 +286,6 @@ void Server::terminateRunLoop() {
     });
 }
 
-Server::~Server() {
-    terminate();
-}
-
 void Server::runLoop() {
     while (!terminated) {
         SleepEx(INFINITE, true);

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -32,7 +32,6 @@ private:
 class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis);
-    ~Server();
 
     // TODO This should be private
     void handleEvents(

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -50,7 +50,6 @@ private:
 class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback);
-    ~Server();
 
 protected:
     void initializeRunLoop() override;

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -61,7 +61,6 @@ private:
 class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, size_t bufferSize, jobject watcherCallback);
-    ~Server();
 
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
     bool executeOnRunLoop(function<bool()> command);


### PR DESCRIPTION
Instedd of utilizing the destructor we now call `terminate()` directly. This way we can avoid calling virtual methods from destructors.