### PR TITLE
Use a native enum for file event types

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -133,7 +133,7 @@ void Server::handleEvents(
 void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags) {
     logToJava(FINE, "Event flags: 0x%x for '%s'", flags, path);
 
-    jint type;
+    FileWatchEventType type;
     if (IS_SET(flags, kFSEventStreamEventFlagHistoryDone)) {
         return;
     } else if (IS_ANY_SET(flags,
@@ -141,28 +141,28 @@ void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags)
                        | kFSEventStreamEventFlagMount
                        | kFSEventStreamEventFlagUnmount
                        | kFSEventStreamEventFlagMustScanSubDirs)) {
-        type = FILE_EVENT_INVALIDATE;
+        type = INVALIDATE;
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemRenamed)) {
         if (IS_SET(flags, kFSEventStreamEventFlagItemCreated)) {
-            type = FILE_EVENT_REMOVED;
+            type = REMOVED;
         } else {
-            type = FILE_EVENT_CREATED;
+            type = CREATED;
         }
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemModified)) {
-        type = FILE_EVENT_MODIFIED;
+        type = MODIFIED;
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemRemoved)) {
-        type = FILE_EVENT_REMOVED;
+        type = REMOVED;
     } else if (IS_ANY_SET(flags,
                    kFSEventStreamEventFlagItemInodeMetaMod    // file locked
                        | kFSEventStreamEventFlagItemFinderInfoMod
                        | kFSEventStreamEventFlagItemChangeOwner
                        | kFSEventStreamEventFlagItemXattrMod)) {
-        type = FILE_EVENT_MODIFIED;
+        type = MODIFIED;
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemCreated)) {
-        type = FILE_EVENT_CREATED;
+        type = CREATED;
     } else {
         logToJava(WARNING, "Unknown event 0x%x for %s", flags, path);
-        type = FILE_EVENT_UNKNOWN;
+        type = UNKNOWN;
     }
 
     u16string pathStr = utf8ToUtf16String(path);

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -55,7 +55,7 @@ AbstractServer::AbstractServer(JNIEnv* env, jobject watcherCallback)
 AbstractServer::~AbstractServer() {
 }
 
-void AbstractServer::reportChange(JNIEnv* env, int type, const u16string& path) {
+void AbstractServer::reportChange(JNIEnv* env, FileWatchEventType type, const u16string& path) {
     jstring javaPath = env->NewString((jchar*) path.c_str(), (jsize) path.length());
     env->CallVoidMethod(watcherCallback.get(), watcherCallbackMethod, type, javaPath);
     env->DeleteLocalRef(javaPath);

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -171,7 +171,7 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
     if (IS_SET(mask, IN_Q_OVERFLOW)) {
         for (auto it : watchPoints) {
             auto path = it.first;
-            reportChange(env, FILE_EVENT_INVALIDATE, path);
+            reportChange(env, INVALIDATE, path);
         }
         return;
     }
@@ -204,17 +204,17 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
         return;
     }
 
-    int type;
+    FileWatchEventType type;
     const u16string name = utf8ToUtf16String(eventName);
     // TODO How to handle MOVE_SELF?
     if (IS_ANY_SET(mask, IN_CREATE | IN_MOVED_TO)) {
-        type = FILE_EVENT_CREATED;
+        type = CREATED;
     } else if (IS_ANY_SET(mask, IN_DELETE | IN_DELETE_SELF | IN_MOVED_FROM)) {
-        type = FILE_EVENT_REMOVED;
+        type = REMOVED;
     } else if (IS_SET(mask, IN_MODIFY)) {
-        type = FILE_EVENT_MODIFIED;
+        type = MODIFIED;
     } else {
-        type = FILE_EVENT_UNKNOWN;
+        type = UNKNOWN;
     }
 
     if (!name.empty()) {

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -19,11 +19,13 @@
 using namespace std;
 
 // Corresponds to values of FileWatcherCallback.Type
-#define FILE_EVENT_CREATED 0
-#define FILE_EVENT_REMOVED 1
-#define FILE_EVENT_MODIFIED 2
-#define FILE_EVENT_INVALIDATE 3
-#define FILE_EVENT_UNKNOWN 4
+enum FileWatchEventType {
+    CREATED,
+    REMOVED,
+    MODIFIED,
+    INVALIDATE,
+    UNKNOWN
+};
 
 #define IS_SET(flags, flag) (((flags) & (flag)) == (flag))
 #define IS_ANY_SET(flags, mask) (((flags) & (mask)) != 0)
@@ -91,7 +93,7 @@ protected:
     virtual bool unregisterPath(const u16string& path) = 0;
     virtual void terminateRunLoop() = 0;
 
-    void reportChange(JNIEnv* env, int type, const u16string& path);
+    void reportChange(JNIEnv* env, FileWatchEventType type, const u16string& path);
     void reportError(JNIEnv* env, const exception& ex);
 
     mutex mutationMutex;


### PR DESCRIPTION
This is just so much better than the `#define`s we used to use.