### PR TITLE
Use only IS_SET to test for flags

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -136,7 +136,7 @@ void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags)
     FileWatchEventType type;
     if (IS_SET(flags, kFSEventStreamEventFlagHistoryDone)) {
         return;
-    } else if (IS_ANY_SET(flags,
+    } else if (IS_SET(flags,
                    kFSEventStreamEventFlagRootChanged
                        | kFSEventStreamEventFlagMount
                        | kFSEventStreamEventFlagUnmount
@@ -152,7 +152,7 @@ void Server::handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags)
         type = MODIFIED;
     } else if (IS_SET(flags, kFSEventStreamEventFlagItemRemoved)) {
         type = REMOVED;
-    } else if (IS_ANY_SET(flags,
+    } else if (IS_SET(flags,
                    kFSEventStreamEventFlagItemInodeMetaMod    // file locked
                        | kFSEventStreamEventFlagItemFinderInfoMod
                        | kFSEventStreamEventFlagItemChangeOwner

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -163,7 +163,7 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
         ? ""
         : event->name;
     logToJava(FINE, "Event mask: 0x%x for %s (wd = %d, cookie = 0x%x, len = %d)", mask, eventName, event->wd, event->cookie, event->len);
-    if (IS_ANY_SET(mask, IN_UNMOUNT)) {
+    if (IS_SET(mask, IN_UNMOUNT)) {
         return;
     }
 
@@ -207,9 +207,9 @@ void Server::handleEvent(JNIEnv* env, const inotify_event* event) {
     FileWatchEventType type;
     const u16string name = utf8ToUtf16String(eventName);
     // TODO How to handle MOVE_SELF?
-    if (IS_ANY_SET(mask, IN_CREATE | IN_MOVED_TO)) {
+    if (IS_SET(mask, IN_CREATE | IN_MOVED_TO)) {
         type = CREATED;
-    } else if (IS_ANY_SET(mask, IN_DELETE | IN_DELETE_SELF | IN_MOVED_FROM)) {
+    } else if (IS_SET(mask, IN_DELETE | IN_DELETE_SELF | IN_MOVED_FROM)) {
         type = REMOVED;
     } else if (IS_SET(mask, IN_MODIFY)) {
         type = MODIFIED;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -27,8 +27,7 @@ enum FileWatchEventType {
     UNKNOWN
 };
 
-#define IS_SET(flags, flag) (((flags) & (flag)) == (flag))
-#define IS_ANY_SET(flags, mask) (((flags) & (mask)) != 0)
+#define IS_SET(flags, mask) (((flags) & (mask)) != 0)
 
 #define THREAD_TIMEOUT (chrono::seconds(5))
 


### PR DESCRIPTION
There is no advantage to having both `IS_SET` and `IS_ANY_SET` and the ambiguity makes this error-prone.