### PR TITLE
Fix wrong method call for unknown events

### DIFF
--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -67,7 +67,7 @@ void AbstractServer::reportChangeEvent(JNIEnv* env, ChangeType type, const u16st
 
 void AbstractServer::reportUnknownEvent(JNIEnv* env, const u16string& path) {
     jstring javaPath = env->NewString((jchar*) path.c_str(), (jsize) path.length());
-    env->CallVoidMethod(watcherCallback.get(), watcherReportChangeEventMethod, javaPath);
+    env->CallVoidMethod(watcherCallback.get(), watcherReportUnknownEventMethod, javaPath);
     env->DeleteLocalRef(javaPath);
     getJavaExceptionAndPrintStacktrace(env);
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -350,6 +350,22 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
             : [change(CREATED, targetFileInside)]
     }
 
+    def "can rename watched directory"() {
+        given:
+        def watchedDirectory = new File(rootDir, "watched")
+        watchedDirectory.mkdirs()
+        startWatcher(watchedDirectory)
+
+        when:
+        watchedDirectory.renameTo(new File(rootDir, "newWatched"))
+        waitForChangeEventLatency()
+        then:
+        if (Platform.current().linux) {
+            expectLogMessage(WARNING, Pattern.compile("Unknown event 0x800 for ${Pattern.quote(watchedDirectory.absolutePath)}"))
+        }
+        noExceptionThrown()
+    }
+
     def "can receive multiple events from the same directory"() {
         given:
         def firstFile = new File(rootDir, "first.txt")


### PR DESCRIPTION
We tried to call the `changeEvent` method instead of the `unknownEvent` method for unknown events. This caused JVM crashes.

The crash has been exposed by the unknown event caused by renaming the watched directory on Linux. I added a test for this.