### PR TITLE
Do not fail if cancelling watch point returns EINVAL

### DIFF
--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -44,11 +44,28 @@ enum class WatchPointStatus {
     CANCELLED
 };
 
+enum class CancelResult {
+    /**
+     * The watch point was successfully cancelled.
+     */
+    CANCELLED,
+
+    /**
+     * The watch point was not cancelled (probably because it was removed).
+     */
+    NOT_CANCELLED,
+
+    /**
+     * The watch poing has already been cancelled earlier.
+     */
+    ALREADY_CANCELLED
+};
+
 class WatchPoint {
 public:
     WatchPoint(const u16string& path, const shared_ptr<Inotify> inotify, int watchDescriptor);
 
-    bool cancel();
+    CancelResult cancel();
 
 private:
     WatchPointStatus status;


### PR DESCRIPTION
This is a sign that the watch point has been removed recently and we should treat it as a normal event and not fail.

Fixes https://github.com/gradle/native-platform/issues/195.