### PR TITLE
Always sleep on cancel on Windows

### DIFF
--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -61,9 +61,8 @@ bool WatchPoint::cancel() {
 
 WatchPoint::~WatchPoint() {
     try {
-        if (cancel()) {
-            SleepEx(0, true);
-        }
+        cancel();
+        SleepEx(0, true);
         close();
     } catch (const exception& ex) {
         logToJava(LogLevel::WARNING, "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());


### PR DESCRIPTION
Though the underlying problem may be that
a non-cancelled WatchPoint still can receive
events, depending on the reason it can't be
cancelled.