### PR TITLE
Throw specialized exceptions for Linux inotify limits

### DIFF
--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -44,16 +44,12 @@ FileWatcherException::FileWatcherException(const string& message)
     : runtime_error(message) {
 }
 
+JavaExceptionThrownException::JavaExceptionThrownException()
+    : runtime_error("Java exception thrown from native code") {
+}
+
 InsufficientResourcesFileWatcherException::InsufficientResourcesFileWatcherException(const string& message)
     : FileWatcherException(message) {
-}
-
-InotifyInstanceLimitTooLowException::InotifyInstanceLimitTooLowException()
-    : InsufficientResourcesFileWatcherException("Inotify instance limit too low") {
-}
-
-InotifyWatchesLimitTooLowException::InotifyWatchesLimitTooLowException()
-    : InsufficientResourcesFileWatcherException("Inotify watches limit too low") {
 }
 
 AbstractServer::AbstractServer(JNIEnv* env, jobject watcherCallback)
@@ -198,8 +194,8 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024Na
         vector<u16string> paths;
         javaToUtf16StringArray(env, javaPaths, paths);
         server->registerPaths(paths);
-    } catch (const InotifyWatchesLimitTooLowException& e) {
-        rethrowAsJavaException(env, e, nativePlatformJniConstants->inotifyWatchesLimitTooLowExceptionClass.get());
+    } catch (const JavaExceptionThrownException& e) {
+        // Ignore, the Java exception has already been thrown.
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
     }

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -250,7 +250,5 @@ Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_invalid
 
 NativePlatformJniConstants::NativePlatformJniConstants(JavaVM* jvm)
     : JniSupport(jvm)
-    , nativeExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/NativeException")
-    , inotifyWatchesLimitTooLowExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/InotifyWatchesLimitTooLowException")
-    , inotifyInstanceLimitTooLowExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/InotifyInstanceLimitTooLowException") {
+    , nativeExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/NativeException") {
 }

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -265,7 +265,7 @@ static int addInotifyWatch(const u16string& path, shared_ptr<Inotify> inotify, J
     int fdWatch = inotify_add_watch(inotify->fd, pathNarrow.c_str(), EVENT_MASK);
     if (fdWatch == -1) {
         if (errno == ENOSPC) {
-            rethrowAsJavaException(env, InotifyWatchesLimitTooLowException(), nativePlatformJniConstants->inotifyWatchesLimitTooLowExceptionClass.get());
+            rethrowAsJavaException(env, InotifyWatchesLimitTooLowException(), linuxJniConstants->inotifyWatchesLimitTooLowExceptionClass.get());
             throw JavaExceptionThrownException();
         }
         throw FileWatcherException("Couldn't add watch", path, errno);
@@ -311,9 +311,14 @@ Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_startWatch
     try {
         return wrapServer(env, new Server(env, javaCallback));
     } catch (const InotifyInstanceLimitTooLowException& e) {
-        rethrowAsJavaException(env, e, nativePlatformJniConstants->inotifyInstanceLimitTooLowExceptionClass.get());
+        rethrowAsJavaException(env, e, linuxJniConstants->inotifyInstanceLimitTooLowExceptionClass.get());
         return NULL;
     }
 }
 
+LinuxJniConstants::LinuxJniConstants(JavaVM* jvm)
+    : JniSupport(jvm)
+    , inotifyWatchesLimitTooLowExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/InotifyWatchesLimitTooLowException")
+    , inotifyInstanceLimitTooLowExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/internal/jni/InotifyInstanceLimitTooLowException") {
+}
 #endif

--- a/src/file-events/cpp/services.cpp
+++ b/src/file-events/cpp/services.cpp
@@ -1,8 +1,12 @@
 #include "logging.h"
 #include "generic_fsnotifier.h"
+#include "linux_fsnotifier.h"
 
 BaseJniConstants* baseJniConstants;
 NativePlatformJniConstants* nativePlatformJniConstants;
+#ifdef __linux__
+LinuxJniConstants* linuxJniConstants;
+#endif
 Logging* logging;
 
 JNIEXPORT jint JNICALL
@@ -10,11 +14,17 @@ JNI_OnLoad(JavaVM* jvm, void*) {
     baseJniConstants = new BaseJniConstants(jvm);
     nativePlatformJniConstants = new NativePlatformJniConstants(jvm);
     logging = new Logging(jvm);
+#ifdef __linux__
+    linuxJniConstants = new LinuxJniConstants(jvm);
+#endif
     return JNI_VERSION_1_6;
 }
 
 JNIEXPORT void JNICALL
 JNI_OnUnload(JavaVM*, void*) {
+#ifdef __linux__
+    delete linuxJniConstants;
+#endif
     delete logging;
     delete nativePlatformJniConstants;
     delete baseJniConstants;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -36,6 +36,21 @@ public:
     FileWatcherException(const string& message);
 };
 
+struct InsufficientResourcesFileWatcherException : public FileWatcherException {
+public:
+    InsufficientResourcesFileWatcherException(const string& message);
+};
+
+struct InotifyInstanceLimitTooLowException : public InsufficientResourcesFileWatcherException {
+public:
+    InotifyInstanceLimitTooLowException();
+};
+
+struct InotifyWatchesLimitTooLowException : public InsufficientResourcesFileWatcherException {
+public:
+    InotifyWatchesLimitTooLowException();
+};
+
 class AbstractServer;
 
 class AbstractServer : public JniSupport {
@@ -97,8 +112,13 @@ public:
     NativePlatformJniConstants(JavaVM* jvm);
 
     const JClass nativeExceptionClass;
+    const JClass inotifyWatchesLimitTooLowExceptionClass;
+    const JClass inotifyInstanceLimitTooLowExceptionClass;
 };
 
 extern NativePlatformJniConstants* nativePlatformJniConstants;
 
 jobject wrapServer(JNIEnv* env, AbstractServer* server);
+
+jobject rethrowAsJavaException(JNIEnv* env, const exception& e);
+jobject rethrowAsJavaException(JNIEnv* env, const exception& e, jclass exceptionClass);

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -107,8 +107,6 @@ public:
     NativePlatformJniConstants(JavaVM* jvm);
 
     const JClass nativeExceptionClass;
-    const JClass inotifyWatchesLimitTooLowExceptionClass;
-    const JClass inotifyInstanceLimitTooLowExceptionClass;
 };
 
 extern NativePlatformJniConstants* nativePlatformJniConstants;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -36,6 +36,9 @@ public:
     FileWatcherException(const string& message);
 };
 
+// Throwing a Java exception from native code does not change the program flow.
+// So it may be necessary to throw a native exception as well which then can be catched in the outmost level just before returning to Java.
+// The idea here is that the catch clause for this exception is always empty.
 struct JavaExceptionThrownException : public runtime_error {
 public:
     JavaExceptionThrownException();

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -36,19 +36,14 @@ public:
     FileWatcherException(const string& message);
 };
 
+struct JavaExceptionThrownException : public runtime_error {
+public:
+    JavaExceptionThrownException();
+};
+
 struct InsufficientResourcesFileWatcherException : public FileWatcherException {
 public:
     InsufficientResourcesFileWatcherException(const string& message);
-};
-
-struct InotifyInstanceLimitTooLowException : public InsufficientResourcesFileWatcherException {
-public:
-    InotifyInstanceLimitTooLowException();
-};
-
-struct InotifyWatchesLimitTooLowException : public InsufficientResourcesFileWatcherException {
-public:
-    InotifyWatchesLimitTooLowException();
 };
 
 class AbstractServer;

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -12,6 +12,16 @@
 
 using namespace std;
 
+struct InotifyInstanceLimitTooLowException : public InsufficientResourcesFileWatcherException {
+public:
+    InotifyInstanceLimitTooLowException();
+};
+
+struct InotifyWatchesLimitTooLowException : public InsufficientResourcesFileWatcherException {
+public:
+    InotifyWatchesLimitTooLowException();
+};
+
 class Server;
 
 struct Inotify {

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -110,4 +110,14 @@ private:
     vector<uint8_t> buffer;
 };
 
+class LinuxJniConstants : public JniSupport {
+public:
+    LinuxJniConstants(JavaVM* jvm);
+
+    const JClass inotifyWatchesLimitTooLowExceptionClass;
+    const JClass inotifyInstanceLimitTooLowExceptionClass;
+};
+
+extern LinuxJniConstants* linuxJniConstants;
+
 #endif

--- a/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/FileWatcher.java
@@ -1,5 +1,7 @@
 package net.rubygrapefruit.platform.file;
 
+import net.rubygrapefruit.platform.internal.jni.InsufficientResourcesForWatchingException;
+
 import javax.annotation.CheckReturnValue;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.File;
@@ -11,7 +13,7 @@ import java.util.concurrent.TimeUnit;
  */
 @NotThreadSafe
 public interface FileWatcher {
-    void startWatching(Collection<File> paths);
+    void startWatching(Collection<File> paths) throws InsufficientResourcesForWatchingException;
 
     @CheckReturnValue
     boolean stopWatching(Collection<File> paths);

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -1,5 +1,7 @@
 package net.rubygrapefruit.platform.internal.jni;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.NativeIntegration;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
@@ -12,8 +14,6 @@ import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public abstract class AbstractFileEventFunctions implements NativeIntegration {
     public static String getVersion() {
@@ -63,7 +63,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
          *
          * @see FileWatcher#startWatching(Collection)
          */
-        public FileWatcher start(long startTimeout, TimeUnit startTimeoutUnit) throws InterruptedException {
+        public FileWatcher start(long startTimeout, TimeUnit startTimeoutUnit) throws InterruptedException, InsufficientResourcesForWatchingException {
             Object server = startWatcher(new NativeFileWatcherCallback(eventQueue));
             return new NativeFileWatcher(server, startTimeout, startTimeoutUnit);
         }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyInstanceLimitTooLowException.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyInstanceLimitTooLowException.java
@@ -1,0 +1,7 @@
+package net.rubygrapefruit.platform.internal.jni;
+
+public class InotifyInstanceLimitTooLowException extends InsufficientResourcesForWatchingException {
+    public InotifyInstanceLimitTooLowException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyInstanceLimitTooLowException.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyInstanceLimitTooLowException.java
@@ -1,5 +1,9 @@
 package net.rubygrapefruit.platform.internal.jni;
 
+/**
+ * A {@link InotifyInstanceLimitTooLowException} is thrown by {@link AbstractFileEventFunctions.AbstractWatcherBuilder#start()}
+ * when the inotify instance count is too low.
+ */
 public class InotifyInstanceLimitTooLowException extends InsufficientResourcesForWatchingException {
     public InotifyInstanceLimitTooLowException(String message) {
         super(message);

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyWatchesLimitTooLowException.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyWatchesLimitTooLowException.java
@@ -1,5 +1,12 @@
 package net.rubygrapefruit.platform.internal.jni;
 
+import java.util.Collection;
+
+/**
+ * A {@link InotifyInstanceLimitTooLowException} is thrown by {@link net.rubygrapefruit.platform.file.FileWatcher#startWatching(Collection)}
+ * when the inotify watches count is too low.
+ */
+@SuppressWarnings("unused") // Thrown from the native side
 public class InotifyWatchesLimitTooLowException extends InsufficientResourcesForWatchingException {
     public InotifyWatchesLimitTooLowException(String message) {
         super(message);

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyWatchesLimitTooLowException.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/InotifyWatchesLimitTooLowException.java
@@ -1,0 +1,7 @@
+package net.rubygrapefruit.platform.internal.jni;
+
+public class InotifyWatchesLimitTooLowException extends InsufficientResourcesForWatchingException {
+    public InotifyWatchesLimitTooLowException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/InsufficientResourcesForWatchingException.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/InsufficientResourcesForWatchingException.java
@@ -1,0 +1,9 @@
+package net.rubygrapefruit.platform.internal.jni;
+
+import net.rubygrapefruit.platform.NativeException;
+
+public class InsufficientResourcesForWatchingException extends NativeException {
+    public InsufficientResourcesForWatchingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -46,7 +46,7 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
         }
 
         @Override
-        protected Object startWatcher(NativeFileWatcherCallback callback) {
+        protected Object startWatcher(NativeFileWatcherCallback callback) throws InotifyInstanceLimitTooLowException {
             return startWatcher0(callback);
         }
     }


### PR DESCRIPTION
We now throw specialized exception when we reach the inotify limits on Linux. This can then be handled by clients of native platform to display helpful messages.