### PR TITLE
Simplify targetting the agents

### DIFF
--- a/.teamcity/Agent.kt
+++ b/.teamcity/Agent.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-enum class Agent(val os: Os, val architecture: Architecture, val java8Home: String = os.java8Home) {
+enum class Agent(val os: Os, val architecture: Architecture) {
     UbuntuAmd64(os = Os.Ubuntu, architecture = Architecture.Amd64),
-    UbuntuAarch64(os = Os.Ubuntu, architecture = Architecture.Aarch64, java8Home = "/usr/lib/jvm/java-8-openjdk-arm64"),
+    UbuntuAarch64(os = Os.Ubuntu, architecture = Architecture.Aarch64),
     AmazonLinuxAmd64(os = Os.AmazonLinux, architecture = Architecture.Amd64),
     AmazonLinuxAarch64(os = Os.AmazonLinux, architecture = Architecture.Aarch64),
     CentOsAmd64(os = Os.CentOs, architecture = Architecture.Amd64),

--- a/.teamcity/Os.kt
+++ b/.teamcity/Os.kt
@@ -7,16 +7,14 @@ interface Os {
 
     object Ubuntu : Linux(Ncurses.Ncurses5) {
         override fun Requirements.additionalRequirements() {
-            doesNotContain("system.ncurses.version", "ncurses6")
-            doesNotContain(osVersionParameter, "el8")
+            contains(osDistributionNameParameter, "ubuntu")
         }
         override val java8Home: String = "%linux.java8.oracle.64bit%"
     }
 
     object AmazonLinux : Linux(Ncurses.Ncurses6) {
         override fun Requirements.additionalRequirements() {
-            contains("system.ncurses.version", "ncurses6")
-            doesNotContain(osVersionParameter, "el8")
+            contains(osDistributionNameParameter, "amazon")
         }
 
         override val java8Home: String = "%linux.java8.openjdk.aarch64%"
@@ -24,7 +22,7 @@ interface Os {
 
     object CentOs : Linux(Ncurses.Ncurses6) {
         override fun Requirements.additionalRequirements() {
-            contains(osVersionParameter, "el8")
+            contains(osDistributionNameParameter, "centos")
         }
 
         override val java8Home: String = "/usr/lib/jvm/java"
@@ -43,7 +41,7 @@ interface Os {
     }
 }
 
-private const val osVersionParameter = "teamcity.agent.jvm.os.version"
+private const val osDistributionNameParameter = "system.agent.os.distribution.name"
 
 abstract class OsWithNameRequirement(private val osName: String, override val osType: String) : Os {
     override fun addAgentRequirements(requirements: Requirements) {

--- a/.teamcity/Os.kt
+++ b/.teamcity/Os.kt
@@ -2,14 +2,12 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Requirements
 
 interface Os {
     fun addAgentRequirements(requirements: Requirements)
-    val java8Home: String
     val osType: String
 
     object Ubuntu : Linux(Ncurses.Ncurses5) {
         override fun Requirements.additionalRequirements() {
             contains(osDistributionNameParameter, "ubuntu")
         }
-        override val java8Home: String = "%linux.java8.oracle.64bit%"
     }
 
     object AmazonLinux : Linux(Ncurses.Ncurses6) {
@@ -17,7 +15,6 @@ interface Os {
             contains(osDistributionNameParameter, "amazon")
         }
 
-        override val java8Home: String = "%linux.java8.openjdk.aarch64%"
     }
 
     object CentOs : Linux(Ncurses.Ncurses6) {
@@ -25,19 +22,15 @@ interface Os {
             contains(osDistributionNameParameter, "centos")
         }
 
-        override val java8Home: String = "/usr/lib/jvm/java"
     }
 
     object MacOs : OsWithNameRequirement("Mac OS X", "MacOs") {
-        override val java8Home: String = "%macos.java8.oracle.64bit%"
     }
 
     object Windows : OsWithNameRequirement("Windows", "Windows") {
-        override val java8Home: String = "%windows.java8.oracle.64bit%"
     }
 
     object FreeBsd : OsWithNameRequirement("FreeBSD", "FreeBsd") {
-        override val java8Home: String = "%freebsd.java8.openjdk.64bit%"
     }
 }
 

--- a/.teamcity/extensions.kt
+++ b/.teamcity/extensions.kt
@@ -28,7 +28,7 @@ fun Requirements.requireAgent(agent: Agent) {
 
 fun BuildType.runOn(agent: Agent) {
     params {
-        param("env.JAVA_HOME", agent.java8Home)
+        param("env.JAVA_HOME", "%env.JDK_18_x64%")
     }
 
     requirements {


### PR DESCRIPTION
Now that the Linux agents set `agent.os.distribution.name`.