### PR TITLE
Use a single FSEventStream

### DIFF
--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -197,6 +197,7 @@ void Server::handleEvents(
     try {
         for (size_t i = 0; i < numEvents; i++) {
             const FSEventStreamEventFlags flags = eventFlags[i];
+            const FSEventStreamEventId eventId = eventIds[i];
             if (IS_SET(flags, kFSEventStreamEventFlagHistoryDone)) {
                 // Mark all new watch points as able to receive historical events from this point on
                 for (auto& it : watchPoints) {
@@ -205,12 +206,12 @@ void Server::handleEvents(
                     }
                 }
                 finishedProcessingHistoricalEvents = true;
+                logToJava(LogLevel::FINE, "Finished processing historical events (ID %d)", eventId);
                 continue;
             }
 
             FSEventStreamEventFlags normalizedFlags = flags & ~IGNORED_FLAGS;
             const char* path = eventPaths[i];
-            const FSEventStreamEventId eventId = eventIds[i];
             logToJava(LogLevel::FINE, "Event flags: 0x%x (normalized: 0x%x) with ID %d for '%s'",
                 flags, normalizedFlags, eventId, path);
 

--- a/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/src/file-events/cpp/apple_fsnotifier.cpp
@@ -127,7 +127,6 @@ void Server::initializeRunLoop() {
 void Server::runLoop() {
     CFRunLoopRun();
 
-    unique_lock<mutex> lock(mutationMutex);
     closeEventStream();
     CFRelease(messageSource);
 }
@@ -280,7 +279,7 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, const FSEventStream
     reportChangeEvent(env, type, path);
 }
 
-void Server::registerPathsInternal(const vector<u16string>& paths) {
+void Server::registerPaths(const vector<u16string>& paths) {
     executeOnRunLoop(commandTimeoutInMillis, [this, paths]() {
         for (auto& path : paths) {
             if (watchPoints.find(path) != watchPoints.end()) {
@@ -293,7 +292,7 @@ void Server::registerPathsInternal(const vector<u16string>& paths) {
     });
 }
 
-bool Server::unregisterPathsInternal(const vector<u16string>& paths) {
+bool Server::unregisterPaths(const vector<u16string>& paths) {
     return executeOnRunLoop(commandTimeoutInMillis, [this, paths]() {
         bool success = true;
         for (auto& path : paths) {

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -168,18 +168,12 @@ bool AbstractServer::executeOnRunLoop(const long timeout, function<bool()> actio
 
 void AbstractServer::registerPaths(const vector<u16string>& paths) {
     unique_lock<mutex> lock(mutationMutex);
-    for (auto& path : paths) {
-        registerPath(path);
-    }
+    registerPathsInternal(paths);
 }
 
 bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
-    bool success = true;
     unique_lock<mutex> lock(mutationMutex);
-    for (auto& path : paths) {
-        success &= unregisterPath(path);
-    }
-    return success;
+    return unregisterPathsInternal(paths);
 }
 
 bool AbstractServer::awaitTermination(long timeoutInMillis) {

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -166,16 +166,6 @@ bool AbstractServer::executeOnRunLoop(const long timeout, function<bool()> actio
     }
 }
 
-void AbstractServer::registerPaths(const vector<u16string>& paths) {
-    unique_lock<mutex> lock(mutationMutex);
-    registerPathsInternal(paths);
-}
-
-bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
-    unique_lock<mutex> lock(mutationMutex);
-    return unregisterPathsInternal(paths);
-}
-
 bool AbstractServer::awaitTermination(long timeoutInMillis) {
     unique_lock<mutex> terminationLock(terminationMutex);
     if (terminated) {

--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -141,6 +141,31 @@ void AbstractServer::executeRunLoop(JNIEnv* env) {
     terminationVariable.notify_all();
 }
 
+void AbstractServer::executeCommand(Command* command) {
+    try {
+        command->result = command->action();
+    } catch (const exception&) {
+        command->failure = current_exception();
+    }
+    unique_lock<mutex> lock(command->executionMutex);
+    command->executed.notify_all();
+}
+
+bool AbstractServer::executeOnRunLoop(const long timeout, function<bool()> action) {
+    Command command;
+    command.action = action;
+    unique_lock<mutex> lock(command.executionMutex);
+    queueOnRunLoop(&command);
+    auto status = command.executed.wait_for(lock, chrono::milliseconds(timeout));
+    if (status == cv_status::timeout) {
+        throw FileWatcherException("Execution timed out");
+    } else if (command.failure) {
+        rethrow_exception(command.failure);
+    } else {
+        return command.result;
+    }
+}
+
 void AbstractServer::registerPaths(const vector<u16string>& paths) {
     unique_lock<mutex> lock(mutationMutex);
     for (auto& path : paths) {

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -278,6 +278,20 @@ static int addInotifyWatch(const u16string& path, shared_ptr<Inotify> inotify, J
     return fdWatch;
 }
 
+void Server::registerPathsInternal(const vector<u16string>& paths) {
+    for (auto& path : paths) {
+        registerPath(path);
+    }
+}
+
+bool Server::unregisterPathsInternal(const vector<u16string>& paths) {
+    bool success = true;
+    for (auto& path : paths) {
+        success &= unregisterPath(path);
+    }
+    return success;
+}
+
 void Server::registerPath(const u16string& path) {
     auto it = watchPoints.find(path);
     if (it != watchPoints.end()) {

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -91,6 +91,11 @@ Server::Server(JNIEnv* env, jobject watcherCallback)
 void Server::initializeRunLoop() {
 }
 
+void Server::queueOnRunLoop(Command*) {
+    // We don't queue stuff on Linux
+    abort();
+}
+
 void Server::shutdownRunLoop() {
     shutdownEvent.trigger();
 }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -307,7 +307,7 @@ void Server::initializeRunLoop() {
 }
 
 void Server::shutdownRunLoop() {
-    executeOnRunLoop([this]() {
+    executeOnRunLoop(commandTimeoutInMillis, [this]() {
         shouldTerminate = true;
         return true;
     });
@@ -352,52 +352,27 @@ void Server::runLoop() {
     CloseHandle(threadHandle);
 }
 
-struct Command {
-    function<bool()> function;
-    mutex executionMutex;
-    condition_variable executed;
-    bool result;
-    exception_ptr failure;
-};
-
 static void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info) {
     Command* command = (Command*) info;
-    try {
-        command->result = command->function();
-    } catch (const exception&) {
-        command->failure = current_exception();
-    }
-    unique_lock<mutex> lock(command->executionMutex);
-    command->executed.notify_all();
+    Server::executeCommand(command);
 }
 
-bool Server::executeOnRunLoop(function<bool()> function) {
-    Command command;
-    command.function = function;
-    unique_lock<mutex> lock(command.executionMutex);
-    DWORD ret = QueueUserAPC(executeOnRunLoopCallback, threadHandle, (ULONG_PTR) &command);
+void Server::queueOnRunLoop(Command* command) {
+    DWORD ret = QueueUserAPC(executeOnRunLoopCallback, threadHandle, (ULONG_PTR) command);
     if (ret == 0) {
         throw FileWatcherException("Received error while queuing APC", GetLastError());
-    }
-    auto status = command.executed.wait_for(lock, chrono::milliseconds(commandTimeoutInMillis));
-    if (status == cv_status::timeout) {
-        throw FileWatcherException("Execution timed out");
-    } else if (command.failure) {
-        rethrow_exception(command.failure);
-    } else {
-        return command.result;
     }
 }
 
 void Server::registerPaths(const vector<u16string>& paths) {
-    executeOnRunLoop([this, paths]() {
+    executeOnRunLoop(commandTimeoutInMillis, [this, paths]() {
         AbstractServer::registerPaths(paths);
         return true;
     });
 }
 
 bool Server::unregisterPaths(const vector<u16string>& paths) {
-    return executeOnRunLoop([this, paths]() {
+    return executeOnRunLoop(commandTimeoutInMillis, [this, paths]() {
         return AbstractServer::unregisterPaths(paths);
     });
 }

--- a/src/file-events/cpp/win_fsnotifier.cpp
+++ b/src/file-events/cpp/win_fsnotifier.cpp
@@ -140,7 +140,6 @@ void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
 }
 
 void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred) {
-    unique_lock<mutex> lock(mutationMutex);
     JNIEnv* env = getThreadEnv();
     const u16string& path = watchPoint->path;
 
@@ -319,7 +318,6 @@ void Server::runLoop() {
     }
 
     // We have received termination, cancel all watchers
-    unique_lock<mutex> lock(mutationMutex);
     logToJava(LogLevel::FINE, "Finished with run loop, now cancelling remaining watch points", NULL);
     for (auto& it : watchPoints) {
         auto& watchPoint = it.second;
@@ -364,7 +362,7 @@ void Server::queueOnRunLoop(Command* command) {
     }
 }
 
-void Server::registerPathsInternal(const vector<u16string>& paths) {
+void Server::registerPaths(const vector<u16string>& paths) {
     executeOnRunLoop(commandTimeoutInMillis, [this, paths]() {
         for (auto& path : paths) {
             u16string longPath = path;
@@ -384,7 +382,7 @@ void Server::registerPathsInternal(const vector<u16string>& paths) {
     });
 }
 
-bool Server::unregisterPathsInternal(const vector<u16string>& paths) {
+bool Server::unregisterPaths(const vector<u16string>& paths) {
     return executeOnRunLoop(commandTimeoutInMillis, [this, paths]() {
         bool success = true;
         for (auto& path : paths) {

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -37,13 +37,13 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis, long commandTimeoutInMillis);
 
+    virtual void registerPaths(const vector<u16string>& paths) override;
+    virtual bool unregisterPaths(const vector<u16string>& paths) override;
+
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
     virtual void queueOnRunLoop(Command* command) override;
-
-    virtual void registerPathsInternal(const vector<u16string>& paths) override;
-    virtual bool unregisterPathsInternal(const vector<u16string>& paths) override;
 
     void shutdownRunLoop() override;
 

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -30,11 +30,9 @@ protected:
     void runLoop() override;
     virtual void queueOnRunLoop(Command* command) override;
 
-    virtual void registerPaths(const vector<u16string>& paths) override;
-    virtual bool unregisterPaths(const vector<u16string>& paths) override;
+    virtual void registerPathsInternal(const vector<u16string>& paths) override;
+    virtual bool unregisterPathsInternal(const vector<u16string>& paths) override;
 
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;
 
 private:

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -94,8 +94,8 @@ protected:
     virtual void queueOnRunLoop(Command* command) = 0;
     static void executeCommand(Command* command);
 
-    virtual void registerPath(const u16string& path) = 0;
-    virtual bool unregisterPath(const u16string& path) = 0;
+    virtual void registerPathsInternal(const vector<u16string>& paths) = 0;
+    virtual bool unregisterPathsInternal(const vector<u16string>& paths) = 0;
 
     void reportChangeEvent(JNIEnv* env, ChangeType type, const u16string& path);
     void reportUnknownEvent(JNIEnv* env, const u16string& path);

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -71,12 +71,12 @@ public:
     /**
      * Registers new watch point with the server for the given paths.
      */
-    virtual void registerPaths(const vector<u16string>& paths);
+    virtual void registerPaths(const vector<u16string>& paths) = 0;
 
     /**
      * Unregisters watch points with the server for the given paths.
      */
-    virtual bool unregisterPaths(const vector<u16string>& paths);
+    virtual bool unregisterPaths(const vector<u16string>& paths) = 0;
 
     /**
      * Shuts the server down.
@@ -94,16 +94,11 @@ protected:
     virtual void queueOnRunLoop(Command* command) = 0;
     static void executeCommand(Command* command);
 
-    virtual void registerPathsInternal(const vector<u16string>& paths) = 0;
-    virtual bool unregisterPathsInternal(const vector<u16string>& paths) = 0;
-
     void reportChangeEvent(JNIEnv* env, ChangeType type, const u16string& path);
     void reportUnknownEvent(JNIEnv* env, const u16string& path);
     void reportOverflow(JNIEnv* env, const u16string& path);
     void reportFailure(JNIEnv* env, const exception& ex);
     void reportTermination(JNIEnv* env);
-
-    mutex mutationMutex;
 
 private:
     mutex terminationMutex;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <exception>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -51,6 +52,14 @@ public:
 
 class AbstractServer;
 
+struct Command {
+    function<bool()> action;
+    mutex executionMutex;
+    condition_variable executed;
+    bool result;
+    exception_ptr failure;
+};
+
 class AbstractServer : public JniSupport {
 public:
     AbstractServer(JNIEnv* env, jobject watcherCallback);
@@ -81,6 +90,10 @@ public:
 
 protected:
     virtual void runLoop() = 0;
+    bool executeOnRunLoop(const long timeout, function<bool()> function);
+    virtual void queueOnRunLoop(Command* command) = 0;
+    static void executeCommand(Command* command);
+
     virtual void registerPath(const u16string& path) = 0;
     virtual bool unregisterPath(const u16string& path) = 0;
 

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -93,15 +93,18 @@ protected:
     void initializeRunLoop() override;
     void runLoop() override;
     virtual void queueOnRunLoop(Command* command) override;
-
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;
+
+    virtual void registerPathsInternal(const vector<u16string>& paths) override;
+    virtual bool unregisterPathsInternal(const vector<u16string>& paths) override;
 
 private:
     void processQueues(int timeout);
     void handleEvents();
     void handleEvent(JNIEnv* env, const inotify_event* event);
+
+    void registerPath(const u16string& path);
+    bool unregisterPath(const u16string& path);
 
     unordered_map<u16string, WatchPoint> watchPoints;
     unordered_map<int, u16string> watchRoots;

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -92,6 +92,8 @@ public:
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
+    virtual void queueOnRunLoop(Command* command) override;
+
     void registerPath(const u16string& path) override;
     bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -89,14 +89,14 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback);
 
+    virtual void registerPaths(const vector<u16string>& paths) override;
+    virtual bool unregisterPaths(const vector<u16string>& paths) override;
+
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
     virtual void queueOnRunLoop(Command* command) override;
     void shutdownRunLoop() override;
-
-    virtual void registerPathsInternal(const vector<u16string>& paths) override;
-    virtual bool unregisterPathsInternal(const vector<u16string>& paths) override;
 
 private:
     void processQueues(int timeout);
@@ -106,6 +106,7 @@ private:
     void registerPath(const u16string& path);
     bool unregisterPath(const u16string& path);
 
+    mutex mutationMutex;
     unordered_map<u16string, WatchPoint> watchPoints;
     unordered_map<int, u16string> watchRoots;
     unordered_map<int, u16string> recentlyUnregisteredWatchRoots;

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -84,6 +84,9 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, size_t bufferSize, long commandTimeoutInMillis, jobject watcherCallback);
 
+    virtual void registerPaths(const vector<u16string>& paths) override;
+    virtual bool unregisterPaths(const vector<u16string>& paths) override;
+
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
 
 protected:
@@ -91,9 +94,6 @@ protected:
     void runLoop() override;
     virtual void queueOnRunLoop(Command* command) override;
     void shutdownRunLoop() override;
-
-    virtual void registerPathsInternal(const vector<u16string>& paths) override;
-    virtual bool unregisterPathsInternal(const vector<u16string>& paths) override;
 
 private:
     void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info);

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -3,7 +3,6 @@
 #ifdef _WIN32
 
 #include <Shlwapi.h>
-#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -86,7 +85,6 @@ public:
     Server(JNIEnv* env, size_t bufferSize, long commandTimeoutInMillis, jobject watcherCallback);
 
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
-    bool executeOnRunLoop(function<bool()> command);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
     virtual bool unregisterPaths(const vector<u16string>& paths) override;
@@ -94,6 +92,7 @@ public:
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
+    virtual void queueOnRunLoop(Command* command) override;
 
     void registerPath(const u16string& path) override;
     bool unregisterPath(const u16string& path) override;

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -86,17 +86,14 @@ public:
 
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
 
-    virtual void registerPaths(const vector<u16string>& paths) override;
-    virtual bool unregisterPaths(const vector<u16string>& paths) override;
-
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
     virtual void queueOnRunLoop(Command* command) override;
-
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;
+
+    virtual void registerPathsInternal(const vector<u16string>& paths) override;
+    virtual bool unregisterPathsInternal(const vector<u16string>& paths) override;
 
 private:
     void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info);

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class OsxFileEventFunctions extends AbstractFileEventFunctions {
     private static final long DEFAULT_LATENCY_IN_MS = 0;
+    public static final int DEFAULT_COMMAND_TIMEOUT_IN_SECONDS = 5;
 
     @Override
     public WatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
@@ -51,6 +52,7 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
 
     public static class WatcherBuilder extends AbstractWatcherBuilder {
         private long latencyInMillis = DEFAULT_LATENCY_IN_MS;
+        private long commandTimeoutInMillis = TimeUnit.SECONDS.toMillis(DEFAULT_COMMAND_TIMEOUT_IN_SECONDS);
 
         WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
             super(eventQueue);
@@ -68,11 +70,26 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
             return this;
         }
 
+        /**
+         * Sets the timeout for commands to get scheduled on the run loop.
+         *
+         * Commands are {@link FileWatcher#startWatching(Collection)} and
+         * {@link FileWatcher#stopWatching(Collection)},
+         * The maxOS file watcher relies on scheduling the execution of these commands
+         * on the background thread.
+         *
+         * Defaults to {@value DEFAULT_COMMAND_TIMEOUT_IN_SECONDS} seconds.
+         */
+        public WatcherBuilder withCommandTimeout(int timeoutValue, TimeUnit timeoutUnit) {
+            this.commandTimeoutInMillis = timeoutUnit.toMillis(timeoutValue);
+            return this;
+        }
+
         @Override
         protected Object startWatcher(NativeFileWatcherCallback callback) {
-            return startWatcher0(latencyInMillis, callback);
+            return startWatcher0(latencyInMillis, commandTimeoutInMillis, callback);
         }
     }
 
-    private static native Object startWatcher0(long latencyInMillis, NativeFileWatcherCallback callback);
+    private static native Object startWatcher0(long latencyInMillis, long commandTimeoutInMillis, NativeFileWatcherCallback callback);
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -192,7 +192,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def onslaught = new OnslaughtExecuter(
             (otherDirs.collect { otherDir ->
                 { ->
-                    Thread.sleep((long) (Math.random() * 100))
+                    Thread.sleep((long) (Math.random() * 100) + 100)
                     watcher.startWatching(otherDir)
                 } as Runnable
             }) + (changedFiles.collect { changedFile ->

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -209,7 +209,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         when:
         onslaught.start()
-        onslaught.terminate(5, SECONDS)
+        onslaught.terminate(10, SECONDS)
 
         then:
         noExceptionThrown()
@@ -273,6 +273,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         private final ExecutorService executorService
         private final CountDownLatch readyLatch
         private final CountDownLatch startLatch
+        private final AtomicInteger finishedCounter
         private final int numberOfThreads
 
         OnslaughtExecuter(List<Runnable> jobs) {
@@ -280,12 +281,14 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
             this.executorService = Executors.newFixedThreadPool(numberOfThreads)
             this.readyLatch = new CountDownLatch(numberOfThreads)
             this.startLatch = new CountDownLatch(1)
+            this.finishedCounter = new AtomicInteger()
             Collections.shuffle(jobs)
             jobs.each { job ->
                 executorService.submit({ ->
                     readyLatch.countDown()
                     startLatch.await()
                     job.run()
+                    finishedCounter.incrementAndGet()
                 })
             }
         }
@@ -302,7 +305,11 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         void terminate(long timeout, TimeUnit unit) {
             executorService.shutdown()
-            assert executorService.awaitTermination(timeout, unit)
+            try {
+                assert executorService.awaitTermination(timeout, unit)
+            } finally {
+                LOGGER.info("> Finished ${finishedCounter} of ${numberOfThreads} jobs")
+            }
         }
     }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -17,7 +17,6 @@
 package net.rubygrapefruit.platform.file
 
 import net.rubygrapefruit.platform.internal.Platform
-import net.rubygrapefruit.platform.internal.jni.NativeLogger
 import spock.lang.Requires
 import spock.lang.Timeout
 import spock.lang.Unroll
@@ -28,8 +27,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.logging.Level
-import java.util.logging.Logger
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.CREATED
@@ -181,7 +178,6 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
     def "can start and stop watching directories without losing events"() {
         given:
-        Logger.getLogger(NativeLogger.name).level = Level.FINE
         def watchedDir = new File(rootDir, "watchedDir")
         assert watchedDir.mkdir()
         def changedFiles = (1..200).collect { index ->

--- a/src/test/groovy/net/rubygrapefruit/platform/file/SymlinkFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/SymlinkFileEventFunctionsTest.groovy
@@ -163,7 +163,7 @@ class SymlinkFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         expectEvents byPlatform(
-            (MAC_OS): [change(MODIFIED, canonicalFile), change(MODIFIED, canonicalFile)],
+            (MAC_OS): [change(MODIFIED, canonicalFile)],
             (OTHERWISE): [change(MODIFIED, linkedFile), change(MODIFIED, canonicalFile)]
         )
     }


### PR DESCRIPTION
Previously we started an event stream for each individual directory hierarchy we watched. This seems to be overly expensive and there's also a limit of ~1000 event streams per machine that we might hit. So instead we are now using a single event stream that watches multiple directory hierarchies.

This makes adding/removing watches slightly slower.

There's also a change in behavior wrt watching the same directory both directly and via a symlink: in this case changes are not reported twice with the same path anymore, which is arguably better.