### PR TITLE
Run compatibility tests on CentOs

### DIFF
--- a/.teamcity/NativePlatformBuild.kt
+++ b/.teamcity/NativePlatformBuild.kt
@@ -32,9 +32,9 @@ open class NativePlatformBuild(agent: Agent, init: BuildType.() -> Unit = {}) : 
     }
 
     val publishTask = when (agent) {
+        agentForJavaPublication -> " publishJniToLocalRepo publishMainToLocalRepo"
         in agentsForAllJniPublications -> " publishJniToLocalRepo"
         in agentsForNcursesOnlyPublications -> " publishNcursesJniToLocalRepo"
-        agentForJavaPublication -> " publishJniToLocalRepo publishMainToLocalRepo"
         else -> ""
     }
 

--- a/.teamcity/NativePlatformCompatibilityTest.kt
+++ b/.teamcity/NativePlatformCompatibilityTest.kt
@@ -2,12 +2,20 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
 
 class NativePlatformCompatibilityTest(agent: Agent, buildDependencies: List<BuildType>, init: BuildType.() -> Unit = {}) : BuildType({
     name = "Compatibility test on $agent"
     id = RelativeId("CompatibilityTest$agent")
 
     runOn(agent)
+
+    steps {
+        gradle {
+            tasks = "clean :test -PtestVersionFromLocalRepository"
+            buildFile = ""
+        }
+    }
 
     vcs {
         root(DslContext.settingsRoot)

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ versions {
 }
 
 ext.isCiServer = System.getenv().get("CI") != null
+ext.testVersionFromLocalRepository = project.hasProperty('testVersionFromLocalRepository')
 
 tasks.withType(Test) {
     systemProperty "test.directory", layout.buildDirectory.dir("test files").map { it.asFile.absolutePath }.get()
@@ -23,6 +24,8 @@ tasks.withType(Test) {
         maxFailures = 10
         failOnPassedAfterRetry = true
     }
+    classpath = files(configurations.testRuntimeClasspath)
+    classpath.from(sourceSets.test.output)
 }
 
 def testJni = tasks.register("testJni", Test) {
@@ -86,7 +89,23 @@ allprojects {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    testImplementation project(":")
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+}
+
+if (testVersionFromLocalRepository) {
+    group = "new-group-for-root-project"
+    configurations.all {
+        resolutionStrategy.dependencySubstitution {
+            substitute project(':') with module("net.rubygrapefruit:native-platform:${version}")
+        }
+    }
+    repositories {
+        maven {
+            name = "IncomingLocalRepository"
+            url = rootProject.file("incoming-repo")
+        }
+    }
 }
 
 // Only depend on variants which can be built on the current machine
@@ -443,8 +462,10 @@ afterEvaluate {
             binary.tasks.withType(LinkSharedLibrary) { builderTask ->
                 nativeJar.into("net/rubygrapefruit/platform/$variantName") { from builderTask.linkedFile }
             }
-            project.tasks.test {
-                classpath.from nativeJar
+            if (!testVersionFromLocalRepository) {
+                project.tasks.test {
+                    classpath.from nativeJar
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,12 @@ versions {
     nextSnapshot = '5'
 }
 
-ext.isCiServer = System.getenv().get("CI") != null
-ext.testVersionFromLocalRepository = project.hasProperty('testVersionFromLocalRepository')
+ext.isCiServer = providers.environmentVariable("CI").forUseAtConfigurationTime().isPresent()
+
+// Enabling this property means that the tests will try to resolve an external dependency for native platform
+// and test that instead of building native platform for the current machine.
+// The external dependency can live in the file repository `incoming-repo`.
+ext.testVersionFromLocalRepository = providers.gradleProperty('testVersionFromLocalRepository').forUseAtConfigurationTime().isPresent()
 
 tasks.withType(Test) {
     systemProperty "test.directory", layout.buildDirectory.dir("test files").map { it.asFile.absolutePath }.get()
@@ -24,8 +28,10 @@ tasks.withType(Test) {
         maxFailures = 10
         failOnPassedAfterRetry = true
     }
-    classpath = files(configurations.testRuntimeClasspath)
-    classpath.from(sourceSets.test.output)
+    // Reconfigure the classpath for the test task here, so we can use dependency substitution on `testRuntimeClasspath`
+    // to test an external dependency.
+    // We omit `sourceSets.main.output` here and replace it with a test dependency on `project(':')` further down.
+    classpath = files(configurations.testRuntimeClasspath, sourceSets.test.output)
 }
 
 def testJni = tasks.register("testJni", Test) {
@@ -89,11 +95,16 @@ allprojects {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    // We need to add the root project to testImplementation manually, since we changed the wiring
+    // for the test task to not use sourceSets.main.output.
+    // This allows using dependency substitution for the root project.
     testImplementation project(":")
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 
 if (testVersionFromLocalRepository) {
+    // We need to change the group here, since dependency substitution will not replace
+    // a project artifact with an external artifact with the same GAV coordinates.
     group = "new-group-for-root-project"
     configurations.all {
         resolutionStrategy.dependencySubstitution {
@@ -463,7 +474,7 @@ afterEvaluate {
                 nativeJar.into("net/rubygrapefruit/platform/$variantName") { from builderTask.linkedFile }
             }
             if (!testVersionFromLocalRepository) {
-                project.tasks.test {
+                project.tasks.named("test", Test).configure {
                     classpath.from nativeJar
                 }
             }


### PR DESCRIPTION
This PR configures a build on CentOS, so it uses the already built artifacts from the upstream builds to run the native platform test on CentOs 8. It replaces the artifacts built in the current build by the artifacts from an external repository via dependency substitution, so the native libraries are not rebuilt on CentOS.