### PR TITLE
Close event stream before modifying watch point registrations

### DIFF
--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -48,8 +48,14 @@ protected:
     void shutdownRunLoop() override;
 
 private:
-    void updateEventStream();
-    void createEventStream();
+    /**
+     * Opens the FSEventStream if there's anything to watch.
+     */
+    void openEventStream();
+
+    /**
+     * Closes the FSEventStream if one is open, and ensures that all pending events are processed.
+     */
     void closeEventStream();
 
     void handleCommands();


### PR DESCRIPTION
Previously we updated event streams after the changes were made. This could cause race conditions when changes keep coming in for the unregistered events.