### PR TITLE
Fix watch point mutation locking

### DIFF
--- a/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/src/file-events/cpp/generic_fsnotifier.cpp
@@ -141,22 +141,6 @@ void AbstractServer::executeRunLoop(JNIEnv* env) {
     terminationVariable.notify_all();
 }
 
-void AbstractServer::registerPaths(const vector<u16string>& paths) {
-    unique_lock<mutex> lock(mutationMutex);
-    for (auto& path : paths) {
-        registerPath(path);
-    }
-}
-
-bool AbstractServer::unregisterPaths(const vector<u16string>& paths) {
-    bool success = true;
-    unique_lock<mutex> lock(mutationMutex);
-    for (auto& path : paths) {
-        success &= unregisterPath(path);
-    }
-    return success;
-}
-
 bool AbstractServer::awaitTermination(long timeoutInMillis) {
     unique_lock<mutex> terminationLock(terminationMutex);
     if (terminated) {

--- a/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/src/file-events/cpp/linux_fsnotifier.cpp
@@ -156,7 +156,7 @@ void Server::handleEvents() {
                 break;
             default:
                 // Handle events
-                unique_lock<mutex> lock(mutationMutex);
+                unique_lock<recursive_mutex> lock(mutationMutex);
                 JNIEnv* env = getThreadEnv();
                 logToJava(LogLevel::FINE, "Processing %d bytes worth of events", bytesRead);
                 int index = 0;
@@ -271,6 +271,22 @@ static int addInotifyWatch(const u16string& path, shared_ptr<Inotify> inotify, J
         throw FileWatcherException("Couldn't add watch", path, errno);
     }
     return fdWatch;
+}
+
+void Server::registerPaths(const vector<u16string>& paths) {
+    unique_lock<recursive_mutex> lock(mutationMutex);
+    for (auto& path : paths) {
+        registerPath(path);
+    }
+}
+
+bool Server::unregisterPaths(const vector<u16string>& paths) {
+    unique_lock<recursive_mutex> lock(mutationMutex);
+    bool success = true;
+    for (auto& path : paths) {
+        success &= unregisterPath(path);
+    }
+    return success;
 }
 
 void Server::registerPath(const u16string& path) {

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -43,11 +43,12 @@ protected:
     void shutdownRunLoop() override;
 
 private:
-    void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags);
+    void handleEvent(JNIEnv* env, char* path, FSEventStreamEventFlags flags, FSEventStreamEventId eventId);
     void handleEvents(
         size_t numEvents,
         char** eventPaths,
-        const FSEventStreamEventFlags eventFlags[]);
+        const FSEventStreamEventFlags eventFlags[],
+        const FSEventStreamEventId eventIds[]);
 
     friend void handleEventsCallback(
         ConstFSEventStreamRef stream,

--- a/src/file-events/headers/apple_fsnotifier.h
+++ b/src/file-events/headers/apple_fsnotifier.h
@@ -33,12 +33,13 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback, long latencyInMillis);
 
+    virtual void registerPaths(const vector<u16string>& paths) override;
+    virtual bool unregisterPaths(const vector<u16string>& paths) override;
+
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
 
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;
 
 private:
@@ -57,6 +58,7 @@ private:
         const FSEventStreamEventId eventIds[]);
 
     const long latencyInMillis;
+    recursive_mutex mutationMutex;
     unordered_map<u16string, WatchPoint> watchPoints;
 
     CFRunLoopRef threadLoop;

--- a/src/file-events/headers/generic_fsnotifier.h
+++ b/src/file-events/headers/generic_fsnotifier.h
@@ -62,12 +62,12 @@ public:
     /**
      * Registers new watch point with the server for the given paths.
      */
-    virtual void registerPaths(const vector<u16string>& paths);
+    virtual void registerPaths(const vector<u16string>& paths) = 0;
 
     /**
      * Unregisters watch points with the server for the given paths.
      */
-    virtual bool unregisterPaths(const vector<u16string>& paths);
+    virtual bool unregisterPaths(const vector<u16string>& paths) = 0;
 
     /**
      * Shuts the server down.
@@ -81,16 +81,12 @@ public:
 
 protected:
     virtual void runLoop() = 0;
-    virtual void registerPath(const u16string& path) = 0;
-    virtual bool unregisterPath(const u16string& path) = 0;
 
     void reportChangeEvent(JNIEnv* env, ChangeType type, const u16string& path);
     void reportUnknownEvent(JNIEnv* env, const u16string& path);
     void reportOverflow(JNIEnv* env, const u16string& path);
     void reportFailure(JNIEnv* env, const exception& ex);
     void reportTermination(JNIEnv* env);
-
-    mutex mutationMutex;
 
 private:
     mutex terminationMutex;

--- a/src/file-events/headers/linux_fsnotifier.h
+++ b/src/file-events/headers/linux_fsnotifier.h
@@ -89,11 +89,12 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback);
 
+    virtual void registerPaths(const vector<u16string>& paths) override;
+    virtual bool unregisterPaths(const vector<u16string>& paths) override;
+
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;
 
 private:
@@ -101,6 +102,10 @@ private:
     void handleEvents();
     void handleEvent(JNIEnv* env, const inotify_event* event);
 
+    void registerPath(const u16string& path);
+    bool unregisterPath(const u16string& path);
+
+    recursive_mutex mutationMutex;
     unordered_map<u16string, WatchPoint> watchPoints;
     unordered_map<int, u16string> watchRoots;
     unordered_map<int, u16string> recentlyUnregisteredWatchRoots;

--- a/src/file-events/headers/win_fsnotifier.h
+++ b/src/file-events/headers/win_fsnotifier.h
@@ -94,13 +94,13 @@ public:
 protected:
     void initializeRunLoop() override;
     void runLoop() override;
-
-    void registerPath(const u16string& path) override;
-    bool unregisterPath(const u16string& path) override;
     void shutdownRunLoop() override;
 
 private:
     void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info);
+
+    void registerPath(const u16string& path);
+    bool unregisterPath(const u16string& path);
 
     HANDLE threadHandle;
     const size_t bufferSize;

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -94,7 +94,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def inTheMiddleLatch = new CountDownLatch(numberOfThreads)
         def changeCount = new AtomicInteger()
         def watcher = startNewWatcher()
-        def onslaught = new OnslaughtExecuter(watchedDirectories.collectMany { watchedDirectory ->
+        def onslaught = new OnslaughtExecutor(watchedDirectories.collectMany { watchedDirectory ->
             (1..numberOfParallelWritersPerWatchedDirectory).collect { index ->
                 def fileToChange = new File(watchedDirectory, "file${index}.txt")
                 fileToChange.createNewFile()
@@ -151,7 +151,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
     }
 
     @Requires({ Platform.current().linux })
-    def "can stop watching directory hiearchy while it is being deleted"() {
+    def "can stop watching directory hierarchy while it is being deleted"() {
         given:
         def watchedDirectoryDepth = 8
         ignoreLogMessages()
@@ -160,7 +160,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         assert watchedDir.mkdir()
         List<File> watchedDirectories = createHierarchy(watchedDir, watchedDirectoryDepth)
         def watcher = startNewWatcher()
-        def onslaught = new OnslaughtExecuter(watchedDirectories.collect { watchedDirectory ->
+        def onslaught = new OnslaughtExecutor(watchedDirectories.collect { watchedDirectory ->
             return { -> watcher.stopWatching(watchedDirectory) } as Runnable
         })
 
@@ -202,7 +202,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
                 dir.delete()
             } as Runnable
         }
-        def onslaught = new OnslaughtExecuter(stopWatchingJobs + deleteDirectoriesJobs)
+        def onslaught = new OnslaughtExecutor(stopWatchingJobs + deleteDirectoriesJobs)
 
         onslaught.awaitReady()
         watcher.startWatching(watchedDirectories)
@@ -269,14 +269,14 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         }
     }
 
-    private static class OnslaughtExecuter {
+    private static class OnslaughtExecutor {
         private final ExecutorService executorService
         private final CountDownLatch readyLatch
         private final CountDownLatch startLatch
         private final AtomicInteger finishedCounter
         private final int numberOfThreads
 
-        OnslaughtExecuter(List<Runnable> jobs) {
+        OnslaughtExecutor(List<Runnable> jobs) {
             this.numberOfThreads = jobs.size()
             this.executorService = Executors.newFixedThreadPool(numberOfThreads)
             this.readyLatch = new CountDownLatch(numberOfThreads)


### PR DESCRIPTION
We've been using `mutex` in a bad way:

* on Windows we don't even need to guard `watchPoints` as all the mutation happens on the run loop thread anyway, so that's removed now,
* for macOS and Linux we should have been using `recursive_mutex` instead, as it allows reentry—this is also fixed now.

After #238 has been reverted in #248, we can still salvage a number of improvements that happened as part of the original PR. These are ported here, too.