### PR TITLE
Only wait for the watcher thread to finish if there is some time remaining

### DIFF
--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -224,7 +224,9 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
             if (successful) {
                 long endTime = System.currentTimeMillis();
                 long remainingTimeout = timeoutInMillis - (endTime - startTime);
-                processorThread.join(remainingTimeout);
+                if (remainingTimeout > 0) {
+                    processorThread.join(remainingTimeout);
+                }
                 return !processorThread.isAlive();
             } else {
                 return false;


### PR DESCRIPTION
If the timeout is 0, that means to wait forever, and if the timeout is < 0, then Thread.join() will throw an exception.

Fixes #259.