### PR TITLE
Use Ubuntu 16 images for building native platform

### DIFF
--- a/.teamcity/Agent.kt
+++ b/.teamcity/Agent.kt
@@ -15,8 +15,8 @@
  */
 
 enum class Agent(val os: Os, val architecture: Architecture) {
-    UbuntuAmd64(os = Os.Ubuntu, architecture = Architecture.Amd64),
-    UbuntuAarch64(os = Os.Ubuntu, architecture = Architecture.Aarch64),
+    UbuntuAmd64(os = Os.Ubuntu16, architecture = Architecture.Amd64),
+    UbuntuAarch64(os = Os.Ubuntu16, architecture = Architecture.Aarch64),
     AmazonLinuxAmd64(os = Os.AmazonLinux, architecture = Architecture.Amd64),
     AmazonLinuxAarch64(os = Os.AmazonLinux, architecture = Architecture.Aarch64),
     CentOsAmd64(os = Os.CentOs, architecture = Architecture.Amd64),

--- a/.teamcity/Os.kt
+++ b/.teamcity/Os.kt
@@ -4,9 +4,10 @@ interface Os {
     fun addAgentRequirements(requirements: Requirements)
     val osType: String
 
-    object Ubuntu : Linux(Ncurses.Ncurses5) {
+    object Ubuntu16 : Linux(Ncurses.Ncurses5) {
         override fun Requirements.additionalRequirements() {
             contains(osDistributionNameParameter, "ubuntu")
+            contains(osDistributionVersionParameter, "16")
         }
     }
 
@@ -30,6 +31,7 @@ interface Os {
 }
 
 private const val osDistributionNameParameter = "system.agent.os.distribution.name"
+private const val osDistributionVersionParameter = "system.agent.os.distribution.version"
 
 abstract class OsWithNameRequirement(private val osName: String, override val osType: String) : Os {
     override fun addAgentRequirements(requirements: Requirements) {


### PR DESCRIPTION
So we can keep compatibility with Ubuntu 16 while upgrading our TC agent fleet to Ubuntu 20.