### PR TITLE
Fix bug for resolving file system type on Windows

### DIFF
--- a/native-platform/src/main/cpp/win.cpp
+++ b/native-platform/src/main/cpp/win.cpp
@@ -355,7 +355,6 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixFileSystemFunctions_listFileS
             }
 
             jstring mount_point = wchar_to_java(env, cur, wcslen(cur), result);
-            jstring file_system_type = wchar_to_java(env, fileSystemName, wcslen(fileSystemName), result);
             jstring device_name = wchar_to_java(env, deviceName, wcslen(deviceName), result);
 
             jboolean casePreserving = JNI_TRUE;
@@ -364,7 +363,7 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixFileSystemFunctions_listFileS
                 if (GetVolumeInformationW(cur, NULL, 0, NULL, NULL, &flags, fileSystemName, MAX_PATH + 1) == 0) {
                     env->CallVoidMethod(info, unknownFsMethod,
                         mount_point,
-                        file_system_type,
+                        NULL,
                         device_name,
                         remote);
                     continue;
@@ -378,6 +377,7 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixFileSystemFunctions_listFileS
                 }
             }
 
+            jstring file_system_type = wchar_to_java(env, fileSystemName, wcslen(fileSystemName), result);
             env->CallVoidMethod(info, method,
                 mount_point,
                 file_system_type,

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/file/FileSystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/file/FileSystemInfo.java
@@ -34,10 +34,9 @@ public interface FileSystemInfo {
 
     /**
      * Returns the operating system specific name for the type of this file system
-     * or {@code null} if the type could not be determined
+     * or {@code "unknown"} if the type could not be determined.
      */
     @ThreadSafe
-    @Nullable
     String getFileSystemType();
 
     /**

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/file/FileSystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/file/FileSystemInfo.java
@@ -33,9 +33,11 @@ public interface FileSystemInfo {
     File getMountPoint();
 
     /**
-     * Returns the operating system specific name for the type of this file system.
+     * Returns the operating system specific name for the type of this file system
+     * or {@code null} if the type could not be determined
      */
     @ThreadSafe
+    @Nullable
     String getFileSystemType();
 
     /**

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultFileSystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultFileSystemInfo.java
@@ -30,7 +30,7 @@ public class DefaultFileSystemInfo implements FileSystemInfo {
     private final boolean remote;
     private final CaseSensitivity caseSensitivity;
 
-    public DefaultFileSystemInfo(File mountPoint, String fileSystemType, String deviceName, boolean remote, @Nullable CaseSensitivity caseSensitivity) {
+    public DefaultFileSystemInfo(File mountPoint, @Nullable String fileSystemType, String deviceName, boolean remote, @Nullable CaseSensitivity caseSensitivity) {
         this.mountPoint = mountPoint;
         this.fileSystemType = fileSystemType;
         this.deviceName = deviceName;
@@ -46,6 +46,7 @@ public class DefaultFileSystemInfo implements FileSystemInfo {
         return mountPoint;
     }
 
+    @Nullable
     public String getFileSystemType() {
         return fileSystemType;
     }

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultFileSystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultFileSystemInfo.java
@@ -30,7 +30,7 @@ public class DefaultFileSystemInfo implements FileSystemInfo {
     private final boolean remote;
     private final CaseSensitivity caseSensitivity;
 
-    public DefaultFileSystemInfo(File mountPoint, @Nullable String fileSystemType, String deviceName, boolean remote, @Nullable CaseSensitivity caseSensitivity) {
+    public DefaultFileSystemInfo(File mountPoint, String fileSystemType, String deviceName, boolean remote, @Nullable CaseSensitivity caseSensitivity) {
         this.mountPoint = mountPoint;
         this.fileSystemType = fileSystemType;
         this.deviceName = deviceName;
@@ -46,7 +46,6 @@ public class DefaultFileSystemInfo implements FileSystemInfo {
         return mountPoint;
     }
 
-    @Nullable
     public String getFileSystemType() {
         return fileSystemType;
     }

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultFileSystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultFileSystemInfo.java
@@ -74,4 +74,15 @@ public class DefaultFileSystemInfo implements FileSystemInfo {
         }
         return caseSensitivity;
     }
+
+    @Override
+    public String toString() {
+        return "FileSystemInfo{" +
+            "mountPoint=" + mountPoint +
+            ", fileSystemType='" + fileSystemType + '\'' +
+            ", deviceName='" + deviceName + '\'' +
+            ", remote=" + remote +
+            ", caseSensitivity=" + caseSensitivity +
+            '}';
+    }
 }

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/FileSystemList.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/FileSystemList.java
@@ -32,7 +32,7 @@ public class FileSystemList {
     }
 
     public void addForUnknownCaseSensitivity(String mountPoint, @Nullable String fileSystemType, String deviceName, boolean remote) {
-        fileSystems.add(new DefaultFileSystemInfo(new File(mountPoint), fileSystemType, deviceName, remote, null));
+        fileSystems.add(new DefaultFileSystemInfo(new File(mountPoint), fileSystemType == null ? "unknown" : fileSystemType, deviceName, remote, null));
     }
 
     private static class DefaultCaseSensitivity implements CaseSensitivity {

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/FileSystemList.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/FileSystemList.java
@@ -19,6 +19,7 @@ package net.rubygrapefruit.platform.internal;
 import net.rubygrapefruit.platform.file.CaseSensitivity;
 import net.rubygrapefruit.platform.file.FileSystemInfo;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,12 +27,12 @@ import java.util.List;
 public class FileSystemList {
     public final List<FileSystemInfo> fileSystems = new ArrayList<FileSystemInfo>();
 
-    public void add(String mountPoint, String fileSystemName, String deviceName, boolean remote, boolean caseSensitive, boolean casePreserving) {
-        fileSystems.add(new DefaultFileSystemInfo(new File(mountPoint), fileSystemName, deviceName, remote, new DefaultCaseSensitivity(caseSensitive, casePreserving)));
+    public void add(String mountPoint, String fileSystemType, String deviceName, boolean remote, boolean caseSensitive, boolean casePreserving) {
+        fileSystems.add(new DefaultFileSystemInfo(new File(mountPoint), fileSystemType, deviceName, remote, new DefaultCaseSensitivity(caseSensitive, casePreserving)));
     }
 
-    public void addForUnknownCaseSensitivity(String mountPoint, String fileSystemName, String deviceName, boolean remote) {
-        fileSystems.add(new DefaultFileSystemInfo(new File(mountPoint), fileSystemName, deviceName, remote, null));
+    public void addForUnknownCaseSensitivity(String mountPoint, @Nullable String fileSystemType, String deviceName, boolean remote) {
+        fileSystems.add(new DefaultFileSystemInfo(new File(mountPoint), fileSystemType, deviceName, remote, null));
     }
 
     private static class DefaultCaseSensitivity implements CaseSensitivity {

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/FileSystemList.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/FileSystemList.java
@@ -52,5 +52,13 @@ public class FileSystemList {
         public boolean isCasePreserving() {
             return casePreserving;
         }
+
+        @Override
+        public String toString() {
+            return "CaseSensitivity{" +
+                "caseSensitive=" + caseSensitive +
+                ", casePreserving=" + casePreserving +
+                '}';
+        }
     }
 }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
@@ -31,6 +31,8 @@ class FileSystemsTest extends Specification {
         'ext4',
         'btrfs',
         'xfs',
+        // FreeBSD
+        'ufs',
         // NTFS on Windows
         'NTFS'
     ]

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
@@ -22,7 +22,20 @@ import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 class FileSystemsTest extends Specification {
+    private static final List<String> EXPECTED_FILE_SYSTEM_TYPES = [
+        // APFS on macOS
+        'apfs',
+        // HFS and HFS+ on macOS
+        'hfs',
+        'ext3',
+        'ext4',
+        'btrfs',
+        // NTFS on Windows
+        'NTFS'
+    ]
+
     @Rule TemporaryFolder tmpDir
+
     final FileSystems fileSystems = Native.get(FileSystems.class)
 
     def "caches file systems instance"() {
@@ -36,5 +49,6 @@ class FileSystemsTest extends Specification {
         then:
         mountedFileSystems.collect() { it.mountPoint }.containsAll(File.listRoots())
         mountedFileSystems.every { it.caseSensitivity != null }
+        mountedFileSystems.any { EXPECTED_FILE_SYSTEM_TYPES.contains(it.fileSystemType) }
     }
 }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
@@ -30,6 +30,7 @@ class FileSystemsTest extends Specification {
         'ext3',
         'ext4',
         'btrfs',
+        'xfs',
         // NTFS on Windows
         'NTFS'
     ]


### PR DESCRIPTION
We converted the C-String to a Java String before `GetVolumeInformationW` wrote it.