### PR TITLE
Fix Linux race condition

### DIFF
--- a/file-events/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/generic_fsnotifier.cpp
@@ -2,48 +2,6 @@
 
 #include "generic_fsnotifier.h"
 
-inline string createMessage(const string& message, const u16string& path) {
-    stringstream ss;
-    ss << message;
-    ss << ": ";
-    ss << utf16ToUtf8String(path);
-    return ss.str();
-}
-
-inline string createMessage(const string& message, int errorCode) {
-    stringstream ss;
-    ss << message;
-    ss << ", error = ";
-    ss << errorCode;
-    return ss.str();
-}
-
-inline string createMessage(const string& message, const u16string& path, int errorCode) {
-    stringstream ss;
-    ss << message;
-    ss << ", error = ";
-    ss << errorCode;
-    ss << ": ";
-    ss << utf16ToUtf8String(path);
-    return ss.str();
-}
-
-FileWatcherException::FileWatcherException(const string& message, const u16string& path, int errorCode)
-    : runtime_error(createMessage(message, path, errorCode)) {
-}
-
-FileWatcherException::FileWatcherException(const string& message, const u16string& path)
-    : runtime_error(createMessage(message, path)) {
-}
-
-FileWatcherException::FileWatcherException(const string& message, int errorCode)
-    : runtime_error(createMessage(message, errorCode)) {
-}
-
-FileWatcherException::FileWatcherException(const string& message)
-    : runtime_error(message) {
-}
-
 JavaExceptionThrownException::JavaExceptionThrownException()
     : runtime_error("Java exception thrown from native code") {
 }

--- a/file-events/src/file-events/headers/command.h
+++ b/file-events/src/file-events/headers/command.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <chrono>
+
+using namespace std;
+
+class Command {
+public:
+    Command(function<bool()> function)
+        : function(function) {
+    }
+
+    bool execute(long timeout, function<void(Command*)> scheduleWithRunLoop) {
+        unique_lock<mutex> lock(executionMutex);
+        scheduleWithRunLoop(this);
+        auto status = executed.wait_for(lock, chrono::milliseconds(timeout));
+        if (status == cv_status::timeout) {
+            throw FileWatcherException("Execution timed out");
+        } else if (failure) {
+            rethrow_exception(failure);
+        } else {
+            return result;
+        }
+    }
+
+    void executeInsideRunLoop() {
+        try {
+            result = function();
+        } catch (const exception&) {
+            failure = current_exception();
+        }
+        unique_lock<mutex> lock(executionMutex);
+        executed.notify_all();
+    }
+
+private:
+    function<bool()> function;
+    mutex executionMutex;
+    condition_variable executed;
+    bool result;
+    exception_ptr failure;
+};

--- a/file-events/src/file-events/headers/command.h
+++ b/file-events/src/file-events/headers/command.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
 
@@ -10,8 +11,8 @@ using namespace std;
 
 class Command {
 public:
-    Command(function<bool()> function)
-        : function(function) {
+    Command(function<bool()> work)
+        : work(work) {
     }
 
     bool execute(long timeout, function<void(Command*)> scheduleWithRunLoop) {
@@ -29,7 +30,7 @@ public:
 
     void executeInsideRunLoop() {
         try {
-            result = function();
+            result = work();
         } catch (const exception&) {
             failure = current_exception();
         }
@@ -38,7 +39,7 @@ public:
     }
 
 private:
-    function<bool()> function;
+    function<bool()> work;
     mutex executionMutex;
     condition_variable executed;
     bool result;

--- a/file-events/src/file-events/headers/command.h
+++ b/file-events/src/file-events/headers/command.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <mutex>
-#include <chrono>
+
+#include "exception.h"
 
 using namespace std;
 

--- a/file-events/src/file-events/headers/exception.h
+++ b/file-events/src/file-events/headers/exception.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <exception>
+#include <sstream>
+#include <string>
+
+#include "jni_support.h"
+
+using namespace std;
+
+inline string createMessage(const string& message, const u16string& path) {
+    stringstream ss;
+    ss << message;
+    ss << ": ";
+    ss << utf16ToUtf8String(path);
+    return ss.str();
+}
+
+inline string createMessage(const string& message, int errorCode) {
+    stringstream ss;
+    ss << message;
+    ss << ", error = ";
+    ss << errorCode;
+    return ss.str();
+}
+
+inline string createMessage(const string& message, const u16string& path, int errorCode) {
+    stringstream ss;
+    ss << message;
+    ss << ", error = ";
+    ss << errorCode;
+    ss << ": ";
+    ss << utf16ToUtf8String(path);
+    return ss.str();
+}
+
+struct FileWatcherException : public runtime_error {
+public:
+    FileWatcherException(const string& message, const u16string& path, int errorCode)
+        : runtime_error(createMessage(message, path, errorCode)) {
+    }
+
+    FileWatcherException(const string& message, const u16string& path)
+        : runtime_error(createMessage(message, path)) {
+    }
+
+    FileWatcherException(const string& message, int errorCode)
+        : runtime_error(createMessage(message, errorCode)) {
+    }
+
+    FileWatcherException(const string& message)
+        : runtime_error(message) {
+    }
+};

--- a/file-events/src/file-events/headers/generic_fsnotifier.h
+++ b/file-events/src/file-events/headers/generic_fsnotifier.h
@@ -11,6 +11,7 @@
 #include <thread>
 #include <vector>
 
+#include "exception.h"
 #include "jni_support.h"
 #include "logging.h"
 #include "net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions.h"
@@ -27,14 +28,6 @@ enum class ChangeType {
 };
 
 #define IS_SET(flags, mask) (((flags) & (mask)) != 0)
-
-struct FileWatcherException : public runtime_error {
-public:
-    FileWatcherException(const string& message, const u16string& path, int errorCode);
-    FileWatcherException(const string& message, const u16string& path);
-    FileWatcherException(const string& message, int errorCode);
-    FileWatcherException(const string& message);
-};
 
 // Throwing a Java exception from native code does not change the program flow.
 // So it may be necessary to throw a native exception as well which then can be catched in the outmost level just before returning to Java.

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -114,7 +114,7 @@ private:
 
 class Server : public AbstractServer {
 public:
-    Server(JNIEnv* env, jobject watcherCallback);
+    Server(JNIEnv* env, long commandTimeoutInMillis, jobject watcherCallback);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
     virtual bool unregisterPaths(const vector<u16string>& paths) override;
@@ -139,6 +139,7 @@ private:
     unordered_map<int, u16string> recentlyUnregisteredWatchRoots;
     const shared_ptr<Inotify> inotify;
     CommandEvent commandEvent;
+    const long commandTimeoutInMillis;
     bool shouldTerminate = false;
     vector<uint8_t> buffer;
 };

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
On Windows and macOS we have mechanisms to always execute the `FileWatcher` "commands" on the event handling thread to prevent race conditions with the operating system's notifications. On Linux we previously thought this was not necessary, but it appears that in some cases we do encounter a race condition.

Case in point, Alpine Linux running in Docker seems to have some sort of bug that immediately unregisters a watch descriptor as soon as it is registered, sending an `IN_IGNORED` event. For short Gradle builds this can lead to the daemon crashing. More details here: https://github.com/gradle/gradle/issues/16787, the crash itself looks like this:

```text
Stack: [0x00007f9ae6489000,0x00007f9ae6589af8],  sp=0x00007f9ae6586070,  free space=1012k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libnative-platform-file-events.so+0x3f9fd]  std::_Hashtable<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> >, std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint>, std::allocator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::hash<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_get_previous_node(unsigned long, std::__detail::_Hash_node_base*)+0x2d
C  [libnative-platform-file-events.so+0x3e47a]  std::_Hashtable<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> >, std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint>, std::allocator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::hash<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::erase(std::__detail::_Node_const_iterator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint>, false, true>)+0x46
C  [libnative-platform-file-events.so+0x3d05f]  std::_Hashtable<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> >, std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint>, std::allocator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::hash<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::erase(std::__detail::_Node_iterator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint>, false, true>)+0x45
C  [libnative-platform-file-events.so+0x3c113]  std::unordered_map<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> >, WatchPoint, std::hash<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::equal_to<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > >, std::allocator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint> > >::erase(std::__detail::_Node_iterator<std::pair<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const, WatchPoint>, false, true>)+0x23
C  [libnative-platform-file-events.so+0x3a553]  Server::unregisterPath(std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const&)+0x185
C  [libnative-platform-file-events.so+0x39fd4]  Server::unregisterPaths(std::vector<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> >, std::allocator<std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > > > const&)+0xa0
C  [libnative-platform-file-events.so+0x3628b]  Java_net_rubygrapefruit_platform_internal_jni_AbstractFileEventFunctions_00024NativeFileWatcher_stopWatching0+0x82
j  net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions$NativeFileWatcher.stopWatching0(Ljava/lang/Object;[Ljava/lang/String;)Z+0
j  net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions$NativeFileWatcher.stopWatching(Ljava/util/Collection;)Z+13
j  org.gradle.internal.watch.registry.impl.NonHierarchicalFileWatcherUpdater.updateWatchedDirectories(Ljava/util/Map;)V+103
j  org.gradle.internal.watch.registry.impl.NonHierarchicalFileWatcherUpdater.virtualFileSystemContentsChanged(Ljava/util/Collection;Ljava/util/Collection;Lorg/gradle/internal/snapshot/SnapshotHierarchy;)V+88
```

This PR implements the same mechanism we have on Windows to delegate the execution of `FileWatcher` methods to the run loop.

Note that `FileWatcher` itself is still not thread-safe, i.e. its methods should not be called concurrently. This is explicitly indicated by the `@NotThreadSafe` annotation on `FileWatcher` itself.