### PR TITLE
Ignore already removed watch points on Linux

### DIFF
--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -298,11 +298,10 @@ void Server::registerPath(const u16string& path) {
     if (watchRoots.find(watchDescriptor) != watchRoots.end()) {
         throw FileWatcherException("Already watching path", path);
     }
-    auto result = watchPoints.emplace(piecewise_construct,
+    watchPoints.emplace(piecewise_construct,
         forward_as_tuple(path),
         forward_as_tuple(path, inotify, watchDescriptor));
-    auto& watchPoint = result.first->second;
-    watchRoots[watchPoint.watchDescriptor] = path;
+    watchRoots[watchDescriptor] = path;
 }
 
 bool Server::unregisterPath(const u16string& path) {
@@ -312,13 +311,14 @@ bool Server::unregisterPath(const u16string& path) {
         return false;
     }
     auto& watchPoint = it->second;
+    int wd = watchPoint.watchDescriptor;
     CancelResult ret = watchPoint.cancel();
     if (ret == CancelResult::ALREADY_CANCELLED) {
         return false;
     }
-    recentlyUnregisteredWatchRoots.emplace(watchPoint.watchDescriptor, path);
-    watchRoots.erase(watchPoint.watchDescriptor);
-    watchPoints.erase(it);
+    recentlyUnregisteredWatchRoots.emplace(wd, path);
+    watchRoots.erase(wd);
+    watchPoints.erase(path);
     return ret == CancelResult::CANCELLED;
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
On Alpine Linux in a Docker container we've seen that it is possible that calling `inotify_rm_watch()` immediately produces the `IN_IGNORED` event, which in turn can result in the watch point to be deleted before returning from the `cancel()` method, resulting in a crash.

This change ensures that we ignore already removed watch points instead.