### PR TITLE
Disable file events on non-glibc implementations on Linux

### DIFF
--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -1,6 +1,7 @@
 #ifdef __linux__
 
 #include <codecvt>
+#include <dlfcn.h>
 #include <locale>
 #include <string>
 #include <sys/ioctl.h>
@@ -333,6 +334,18 @@ Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_startWatch
         rethrowAsJavaException(env, e, linuxJniConstants->inotifyInstanceLimitTooLowExceptionClass.get());
         return NULL;
     }
+}
+
+JNIEXPORT jboolean JNICALL
+Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_isGlibc0(JNIEnv*, jclass) {
+    void* libcLibrary = dlopen("libc.so.6", RTLD_LAZY);
+    if (!libcLibrary) {
+        return false;
+    }
+    void* libcVerCheck = dlsym(libcLibrary, "gnu_get_libc_version");
+    jboolean isValid = libcVerCheck != NULL;
+    dlclose(libcLibrary);
+    return isValid;
 }
 
 LinuxJniConstants::LinuxJniConstants(JavaVM* jvm)

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -37,6 +37,9 @@ import java.util.concurrent.BlockingQueue;
 public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
 
     public LinuxFileEventFunctions() {
+        // We have seen some weird behavior on Alpine Linux that uses musl with Gradle that lead to crashes
+        // As a band-aid we currently don't support file events on Linux with a non-glibc libc.
+        // See also https://github.com/gradle/gradle/issues/17099
         if (!isGlibc0()) {
             throw new NativeException("File events on Linux are only supported with glibc");
         }

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -16,6 +16,7 @@
 
 package net.rubygrapefruit.platform.internal.jni;
 
+import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 
@@ -34,6 +35,14 @@ import java.util.concurrent.BlockingQueue;
  * </ul>
  */
 public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
+
+    public LinuxFileEventFunctions() {
+        if (!isGlibc0()) {
+            throw new NativeException("File events on Linux are only supported with glibc");
+        }
+    }
+
+    private static native boolean isGlibc0();
 
     @Override
     public WatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> eventQueue) {


### PR DESCRIPTION
This is primarily targeted at musl libc that seems to have problems with watching files on Linux, causing crashes in Gradle. See https://github.com/gradle/gradle/issues/17099.