### PR TITLE
Use new ReadDirectoryChangesExW() API

### DIFF
--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -84,7 +84,7 @@ bool WatchPoint::isValidDirectory() {
 }
 
 ListenResult WatchPoint::listen() {
-    BOOL success = ReadDirectoryChangesW(
+    BOOL success = ReadDirectoryChangesExW(
         directoryHandle,              // handle to directory
         &buffer[0],                   // read results buffer
         (DWORD) buffer.capacity(),    // length of buffer
@@ -92,7 +92,8 @@ ListenResult WatchPoint::listen() {
         EVENT_MASK,                   // filter conditions
         NULL,                         // bytes returned
         &overlapped,                  // overlapped buffer
-        &handleEventCallback          // completion routine
+        &handleEventCallback,         // completion routine
+        ReadDirectoryNotifyExtendedInformation
     );
     if (success) {
         status = WatchPointStatus::LISTENING;
@@ -176,7 +177,7 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
         } else {
             int index = 0;
             for (;;) {
-                FILE_NOTIFY_INFORMATION* current = (FILE_NOTIFY_INFORMATION*) &buffer[index];
+                FILE_NOTIFY_EXTENDED_INFORMATION* current = (FILE_NOTIFY_EXTENDED_INFORMATION*) &buffer[index];
                 handleEvent(env, path, current);
                 if (current->NextEntryOffset == 0) {
                     break;
@@ -249,7 +250,7 @@ void convertToLongPathIfNeeded(u16string& path) {
     }
 }
 
-void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info) {
+void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_EXTENDED_INFORMATION* info) {
     wstring changedPathW = wstring(info->FileName, 0, info->FileNameLength / sizeof(wchar_t));
     u16string changedPath(changedPathW.begin(), changedPathW.end());
     if (!changedPath.empty()) {

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -274,6 +274,11 @@ void Server::handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_EXTENDE
     } else if (info->Action == FILE_ACTION_REMOVED || info->Action == FILE_ACTION_RENAMED_OLD_NAME) {
         type = ChangeType::REMOVED;
     } else if (info->Action == FILE_ACTION_MODIFIED) {
+        if (info->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            // Ignore MODIFIED events on directories
+            logToJava(LogLevel::FINE, "Ignored MODIFIED event on directory", nullptr);
+            return;
+        }
         type = ChangeType::MODIFIED;
     } else {
         logToJava(LogLevel::WARNING, "Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -97,7 +97,7 @@ protected:
     void shutdownRunLoop() override;
 
 private:
-    void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_INFORMATION* info);
+    void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_EXTENDED_INFORMATION* info);
 
     void registerPath(const u16string& path);
     bool unregisterPath(const u16string& path);

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -314,10 +314,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         sourceFile.renameTo(targetFile)
 
         then:
-        expectEvents byPlatform(
-            (WINDOWS):   [change(REMOVED, sourceFile), change(CREATED, targetFile), change(MODIFIED, subDir)],
-            (OTHERWISE): [change(REMOVED, sourceFile), change(CREATED, targetFile)]
-        )
+        expectEvents change(REMOVED, sourceFile), change(CREATED, targetFile)
     }
 
     def "can detect file moved out"() {

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -297,10 +297,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         sourceFile.renameTo(targetFile)
 
         then:
-        expectEvents byPlatform(
-            (WINDOWS):   [change(REMOVED, sourceFile), change(CREATED, targetFile), optionalChange(MODIFIED, targetFile)],
-            (OTHERWISE): [change(REMOVED, sourceFile), change(CREATED, targetFile)]
-        )
+        expectEvents change(REMOVED, sourceFile), change(CREATED, targetFile)
     }
 
     @IgnoreIf({ Platform.current().linux })
@@ -318,7 +315,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         expectEvents byPlatform(
-            (WINDOWS):   [change(REMOVED, sourceFile), change(CREATED, targetFile), change(MODIFIED, subDir), optionalChange(MODIFIED, targetFile)],
+            (WINDOWS):   [change(REMOVED, sourceFile), change(CREATED, targetFile), change(MODIFIED, subDir)],
             (OTHERWISE): [change(REMOVED, sourceFile), change(CREATED, targetFile)]
         )
     }
@@ -349,14 +346,10 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         startWatcher(rootDir)
 
         when:
-        // On Windows we sometimes get a MODIFIED event after CREATED for some reason
         sourceFileOutside.renameTo(targetFileInside)
 
         then:
-        expectEvents byPlatform(
-            (WINDOWS):   [change(CREATED, targetFileInside), optionalChange(MODIFIED, targetFileInside)],
-            (OTHERWISE): [change(CREATED, targetFileInside)]
-        )
+        expectEvents change(CREATED, targetFileInside)
     }
 
     @Issue("https://github.com/gradle/native-platform/issues/193")
@@ -724,7 +717,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         } else if (Platform.current().linux) {
             expectedEvents << change(REMOVED, removedFile) << change(REMOVED, watchedDir)
         } else if (Platform.current().windows) {
-            expectedEvents << change(MODIFIED, removedFile) << optionalChange(REMOVED, removedFile) << change(REMOVED, watchedDir)
+            expectedEvents << change(MODIFIED, removedFile) << change(REMOVED, removedFile) << change(REMOVED, watchedDir)
         }
 
         then:


### PR DESCRIPTION
Use the new `ReadDirectoryChangesExW()` API (instead of the old `ReadDirectoryChangesW()`) introduced in Windows 10, version 1907 in 2017.

The new API is available on all Windows 10 versions currently supported by Microsoft except for two LTSC versions released in 2015 and 2016. The latest LTSC version released in 2018 is supported.

On unsupported versions of Windows the expected behavior is that the library will fail to load with a missing symbol, and thus we'll report that file events are unavailable.

The new API does not seem to emit as many random extra events (aka "optional events"), though this might be something that was also fixed in the old API in a recent Windows update. In any case, the PR removes most (but not all) `optionalChange()` expectations.