### PR TITLE
Report files changed via short paths as long paths on Windows

### DIFF
--- a/file-events/src/file-events/cpp/jni_support.cpp
+++ b/file-events/src/file-events/cpp/jni_support.cpp
@@ -110,19 +110,6 @@ void javaToUtf16StringArray(JNIEnv* env, jobjectArray javaStrings, vector<u16str
     }
 }
 
-// Utility wrapper to adapt locale-bound facets for wstring convert
-// Exposes the protected destructor as public
-// See https://en.cppreference.com/w/cpp/locale/codecvt
-template <class Facet>
-struct deletable_facet : Facet {
-    template <class... Args>
-    deletable_facet(Args&&... args)
-        : Facet(forward<Args>(args)...) {
-    }
-    ~deletable_facet() {
-    }
-};
-
 u16string utf8ToUtf16String(const char* string) {
     wstring_convert<deletable_facet<codecvt<char16_t, char, mbstate_t>>, char16_t> conv16;
     return conv16.from_bytes(string);

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -3,7 +3,15 @@
 #include "win_fsnotifier.h"
 #include "command.h"
 
+#include <codecvt>
+#include <locale>
+
 using namespace std;
+
+string wideToUtf8String(const wstring& string) {
+    wstring_convert<deletable_facet<codecvt<wchar_t, char, mbstate_t>>, wchar_t> conv;
+    return conv.to_bytes(string);
+}
 
 //
 // WatchPoint
@@ -41,7 +49,7 @@ WatchPoint::WatchPoint(Server* server, size_t eventBufferSize, const wstring& pa
 
 bool WatchPoint::cancel() {
     if (status == WatchPointStatus::LISTENING) {
-        logToJava(LogLevel::FINE, "Cancelling %s", utf16ToUtf8String(path).c_str());
+        logToJava(LogLevel::FINE, "Cancelling %s", wideToUtf8String(pathW).c_str());
         bool cancelled = (bool) CancelIoEx(directoryHandle, &overlapped);
         if (cancelled) {
             status = WatchPointStatus::CANCELLED;
@@ -50,7 +58,7 @@ bool WatchPoint::cancel() {
             close();
             if (cancelError == ERROR_NOT_FOUND) {
                 // Do nothing, looks like this is a typical scenario
-                logToJava(LogLevel::FINE, "Watch point already finished %s", utf16ToUtf8String(path).c_str());
+                logToJava(LogLevel::FINE, "Watch point already finished %s", wideToUtf8String(pathW).c_str());
             } else {
                 throw FileWatcherException("Couldn't cancel watch point", path, cancelError);
             }
@@ -66,7 +74,7 @@ WatchPoint::~WatchPoint() {
         SleepEx(0, true);
         close();
     } catch (const exception& ex) {
-        logToJava(LogLevel::WARNING, "Couldn't cancel watch point %s: %s", utf16ToUtf8String(path).c_str(), ex.what());
+        logToJava(LogLevel::WARNING, "Couldn't cancel watch point %s: %s", wideToUtf8String(pathW).c_str(), ex.what());
     }
 }
 
@@ -112,12 +120,12 @@ void WatchPoint::close() {
         try {
             BOOL ret = CloseHandle(directoryHandle);
             if (!ret) {
-                logToJava(LogLevel::SEVERE, "Couldn't close handle %p for '%ls': %d", directoryHandle, utf16ToUtf8String(path).c_str(), GetLastError());
+                logToJava(LogLevel::SEVERE, "Couldn't close handle %p for '%ls': %d", directoryHandle, wideToUtf8String(pathW).c_str(), GetLastError());
             }
         } catch (const exception& ex) {
             // Apparently with debugging enabled CloseHandle() can also throw, see:
             // https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle#return-value
-            logToJava(LogLevel::SEVERE, "Couldn't close handle %p for '%ls': %s", directoryHandle, utf16ToUtf8String(path).c_str(), ex.what());
+            logToJava(LogLevel::SEVERE, "Couldn't close handle %p for '%ls': %s", directoryHandle, wideToUtf8String(pathW).c_str(), ex.what());
         }
         status = WatchPointStatus::FINISHED;
     }
@@ -125,14 +133,14 @@ void WatchPoint::close() {
 
 void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
     if (errorCode == ERROR_OPERATION_ABORTED) {
-        logToJava(LogLevel::FINE, "Finished watching '%s', status = %d", utf16ToUtf8String(path).c_str(), status);
+        logToJava(LogLevel::FINE, "Finished watching '%s', status = %d", wideToUtf8String(pathW).c_str(), status);
         close();
         return;
     }
 
     if (status != WatchPointStatus::LISTENING) {
         logToJava(LogLevel::FINE, "Ignoring incoming events for %s as watch-point is not listening (%d bytes, errorCode = %d, status = %d)",
-            utf16ToUtf8String(path).c_str(), bytesTransferred, errorCode, status);
+            wideToUtf8String(pathW).c_str(), bytesTransferred, errorCode, status);
         return;
     }
     status = WatchPointStatus::NOT_LISTENING;
@@ -157,7 +165,7 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
 
         if (shouldTerminate) {
             logToJava(LogLevel::FINE, "Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
-                utf16ToUtf8String(path).c_str(), bytesTransferred, watchPoint->status);
+                wideToUtf8String(pathW).c_str(), bytesTransferred, watchPoint->status);
             return;
         }
 
@@ -189,7 +197,7 @@ void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<
             case ListenResult::SUCCESS:
                 break;
             case ListenResult::DELETED:
-                logToJava(LogLevel::FINE, "Watched directory removed for %s", utf16ToUtf8String(path).c_str());
+                logToJava(LogLevel::FINE, "Watched directory removed for %s", wideToUtf8String(pathW).c_str());
                 reportChangeEvent(env, ChangeType::REMOVED, path);
                 break;
         }
@@ -275,9 +283,8 @@ void Server::handleEvent(JNIEnv* env, const wstring& watchedPathW, FILE_NOTIFY_E
             longChangedPathW.erase(0, 4);
         }
     }
-    u16string changedPath(longChangedPathW.begin(), longChangedPathW.end());
 
-    logToJava(LogLevel::FINE, "Change detected: 0x%x '%s'", info->Action, utf16ToUtf8String(changedPath).c_str());
+    logToJava(LogLevel::FINE, "Change detected: 0x%x '%s'", info->Action, wideToUtf8String(longChangedPathW).c_str());
 
     ChangeType type;
     if (info->Action == FILE_ACTION_ADDED || info->Action == FILE_ACTION_RENAMED_NEW_NAME) {
@@ -292,12 +299,12 @@ void Server::handleEvent(JNIEnv* env, const wstring& watchedPathW, FILE_NOTIFY_E
         }
         type = ChangeType::MODIFIED;
     } else {
-        logToJava(LogLevel::WARNING, "Unknown event 0x%x for %s", info->Action, utf16ToUtf8String(changedPath).c_str());
-        reportUnknownEvent(env, changedPath);
+        logToJava(LogLevel::WARNING, "Unknown event 0x%x for %s", info->Action, wideToUtf8String(longChangedPathW).c_str());
+        reportUnknownEvent(env, u16string(longChangedPathW.begin(), longChangedPathW.end()));
         return;
     }
 
-    reportChangeEvent(env, type, changedPath);
+    reportChangeEvent(env, type, u16string(longChangedPathW.begin(), longChangedPathW.end()));
 }
 
 //
@@ -361,7 +368,7 @@ void Server::runLoop() {
                 break;
             default:
                 logToJava(LogLevel::WARNING, "Watch point %s did not finish before termination timeout (status = %d)",
-                    utf16ToUtf8String(watchPoint.path).c_str(), watchPoint.status);
+                    wideToUtf8String(watchPoint.pathW).c_str(), watchPoint.status);
                 break;
         }
     }
@@ -408,10 +415,11 @@ void Server::registerPath(const u16string& path) {
     convertToLongPathIfNeeded(longPathW);
     auto it = watchPoints.find(longPathW);
     if (it != watchPoints.end()) {
-        if (it->second.status != WatchPointStatus::FINISHED) {
+        if (it->second.status == WatchPointStatus::FINISHED) {
+            watchPoints.erase(it);
+        } else {
             throw FileWatcherException("Already watching path", path);
         }
-        watchPoints.erase(it);
     }
     watchPoints.emplace(piecewise_construct,
         forward_as_tuple(longPathW),
@@ -422,7 +430,7 @@ bool Server::unregisterPath(const u16string& path) {
     wstring longPathW(path.begin(), path.end());
     convertToLongPathIfNeeded(longPathW);
     if (watchPoints.erase(longPathW) == 0) {
-        logToJava(LogLevel::INFO, "Path is not watched: %s", utf16ToUtf8String(path).c_str());
+        logToJava(LogLevel::INFO, "Path is not watched: %s", wideToUtf8String(longPathW).c_str());
         return false;
     }
     return true;

--- a/file-events/src/file-events/headers/jni_support.h
+++ b/file-events/src/file-events/headers/jni_support.h
@@ -7,6 +7,19 @@
 
 using namespace std;
 
+// Utility wrapper to adapt locale-bound facets for wstring convert
+// Exposes the protected destructor as public
+// See https://en.cppreference.com/w/cpp/locale/codecvt
+template <class Facet>
+struct deletable_facet : Facet {
+    template <class... Args>
+    deletable_facet(Args&&... args)
+        : Facet(forward<Args>(args)...) {
+    }
+    ~deletable_facet() {
+    }
+};
+
 template <typename T>
 class JniGlobalRef;
 

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -59,7 +59,7 @@ enum class WatchPointStatus {
 
 class WatchPoint {
 public:
-    WatchPoint(Server* server, size_t bufferSize, const wstring& path);
+    WatchPoint(Server* server, size_t eventBufferSize, const wstring& path);
     ~WatchPoint();
 
     ListenResult listen();
@@ -75,7 +75,7 @@ private:
     friend class Server;
     HANDLE directoryHandle;
     OVERLAPPED overlapped;
-    vector<BYTE> buffer;
+    vector<BYTE> eventBuffer;
     WatchPointStatus status;
 
     void handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred);
@@ -84,9 +84,9 @@ private:
 
 class Server : public AbstractServer {
 public:
-    Server(JNIEnv* env, size_t bufferSize, long commandTimeoutInMillis, jobject watcherCallback);
+    Server(JNIEnv* env, size_t eventBufferSize, long commandTimeoutInMillis, jobject watcherCallback);
 
-    void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
+    void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& eventBuffer, DWORD bytesTransferred);
     bool executeOnRunLoop(function<bool()> command);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
@@ -104,7 +104,7 @@ private:
     bool unregisterPath(const u16string& path);
 
     HANDLE threadHandle;
-    const size_t bufferSize;
+    const size_t eventBufferSize;
     const long commandTimeoutInMillis;
     unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -59,7 +59,7 @@ enum class WatchPointStatus {
 
 class WatchPoint {
 public:
-    WatchPoint(Server* server, size_t bufferSize, const u16string& path);
+    WatchPoint(Server* server, size_t bufferSize, const wstring& path);
     ~WatchPoint();
 
     ListenResult listen();
@@ -70,6 +70,7 @@ private:
     void close();
 
     Server* server;
+    const wstring pathW;
     const u16string path;
     friend class Server;
     HANDLE directoryHandle;
@@ -97,7 +98,7 @@ protected:
     void shutdownRunLoop() override;
 
 private:
-    void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_EXTENDED_INFORMATION* info);
+    void handleEvent(JNIEnv* env, const wstring& watchedPath, FILE_NOTIFY_EXTENDED_INFORMATION* info);
 
     void registerPath(const u16string& path);
     bool unregisterPath(const u16string& path);
@@ -105,7 +106,7 @@ private:
     HANDLE threadHandle;
     const size_t bufferSize;
     const long commandTimeoutInMillis;
-    unordered_map<u16string, WatchPoint> watchPoints;
+    unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
 };

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -107,6 +107,7 @@ private:
     const size_t eventBufferSize;
     const long commandTimeoutInMillis;
     unordered_map<wstring, WatchPoint> watchPoints;
+    vector<wchar_t> longPathBuffer;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
 };

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -20,6 +20,7 @@ import net.rubygrapefruit.platform.internal.Platform
 import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions
 import net.rubygrapefruit.platform.internal.jni.NativeLogger
 import org.junit.Assume
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Requires
@@ -688,6 +689,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         "URL-quoted"     | "test%<directory>#2.txt" | !Platform.current().windows
     }
 
+    @Ignore("Doesn't work yet")
     @Requires({ Platform.current().windows })
     def "can detect changes in directory with long path referred to via short path"() {
         given:

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -194,6 +194,29 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         expectEvents change(REMOVED, removedDir)
     }
 
+    @IgnoreIf({ Platform.current().linux })
+    def "can detect hierarchy removed"() {
+        given:
+        def removedDir = new File(rootDir, "removed")
+        assert removedDir.mkdirs()
+        def removedSubDir = new File(removedDir, "sub-dir")
+        assert removedSubDir.mkdirs()
+        def removedSubSubDir = new File(removedSubDir, "sub-sub-dir")
+        assert removedSubSubDir.mkdirs()
+        def removedFile = new File(removedSubSubDir, "file.txt")
+        createNewFile(removedFile)
+        startWatcher(rootDir)
+
+        when:
+        removedDir.deleteDir()
+
+        then:
+        expectEvents byPlatform(
+            (WINDOWS):   [change(MODIFIED, removedFile), change(REMOVED, removedFile), change(REMOVED, removedSubSubDir), change(REMOVED, removedSubDir), change(REMOVED, removedDir)],
+            (OTHERWISE): [change(REMOVED, removedFile), change(REMOVED, removedSubSubDir), change(REMOVED, removedSubDir), change(REMOVED, removedDir)]
+        )
+    }
+
     def "can detect file modified"() {
         given:
         def modifiedFile = new File(rootDir, "modified.txt")
@@ -689,7 +712,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         "URL-quoted"     | "test%<directory>#2.txt" | !Platform.current().windows
     }
 
-    @Ignore("Doesn't work yet")
     @Requires({ Platform.current().windows })
     def "can detect changes in directory with long path referred to via short path"() {
         given:


### PR DESCRIPTION
When a file (e.g. `test-file.txt`) is changed via its short name (`TEST-F~1.TXT`) instead of its long name, the notification also arrives using the short name. Actually, the WINAPI docs say it's not even sure which:

> If there is both a short and long name for the file, the function will return one of these names, but it is unspecified which one.

https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-file_notify_extended_information#:~:text=character.-,filename,-A

This can be confusing for clients that keep track of the long names. This PR adds a way to enforce a consistent behavior where changes are always reported against the long path.