### PR TITLE
Handle watched directory moved on Windows

### DIFF
--- a/file-events/src/file-events/cpp/jni_support.cpp
+++ b/file-events/src/file-events/cpp/jni_support.cpp
@@ -110,19 +110,6 @@ void javaToUtf16StringArray(JNIEnv* env, jobjectArray javaStrings, vector<u16str
     }
 }
 
-// Utility wrapper to adapt locale-bound facets for wstring convert
-// Exposes the protected destructor as public
-// See https://en.cppreference.com/w/cpp/locale/codecvt
-template <class Facet>
-struct deletable_facet : Facet {
-    template <class... Args>
-    deletable_facet(Args&&... args)
-        : Facet(forward<Args>(args)...) {
-    }
-    ~deletable_facet() {
-    }
-};
-
 u16string utf8ToUtf16String(const char* string) {
     wstring_convert<deletable_facet<codecvt<char16_t, char, mbstate_t>>, char16_t> conv16;
     return conv16.from_bytes(string);

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -85,7 +85,7 @@ WatchPoint::WatchPoint(Server* server, size_t eventBufferSize, const wstring& pa
     , status(WatchPointStatus::NOT_LISTENING)
     , server(server) {
     HANDLE directoryHandle = CreateFileW(
-        path.c_str(),          // pointer to the file name
+        path.c_str(),           // pointer to the file name
         FILE_LIST_DIRECTORY,    // access (read/write) mode
         CREATE_SHARE,           // share mode
         NULL,                   // security descriptor
@@ -149,8 +149,7 @@ wstring WatchPoint::getPath() {
         this->directoryHandle,
         &buffer[0],
         PATH_BUFFER_SIZE,
-        FILE_NAME_OPENED
-    );
+        FILE_NAME_OPENED);
     if (pathLength == 0 || pathLength > PATH_BUFFER_SIZE) {
         throw FileWatcherException("Error received when resolving file path", GetLastError());
     }
@@ -171,16 +170,15 @@ bool WatchPoint::isValidDirectory() {
 
 ListenResult WatchPoint::listen() {
     BOOL success = ReadDirectoryChangesExW(
-        directoryHandle,              // handle to directory
+        directoryHandle,                   // handle to directory
         &eventBuffer[0],                   // read results buffer
         (DWORD) eventBuffer.capacity(),    // length of buffer
-        TRUE,                         // include children
-        EVENT_MASK,                   // filter conditions
-        NULL,                         // bytes returned
-        &overlapped,                  // overlapped buffer
-        &handleEventCallback,         // completion routine
-        ReadDirectoryNotifyExtendedInformation
-    );
+        TRUE,                              // include children
+        EVENT_MASK,                        // filter conditions
+        NULL,                              // bytes returned
+        &overlapped,                       // overlapped buffer
+        &handleEventCallback,              // completion routine
+        ReadDirectoryNotifyExtendedInformation);
     if (success) {
         status = WatchPointStatus::LISTENING;
         return ListenResult::SUCCESS;

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -462,6 +462,7 @@ void Server::stopWatchingMovedPaths(jobject droppedPaths) {
             jstring javaPath = env->NewString((jchar*) wideToUtf16String(registeredPath).c_str(), (jsize) registeredPath.length());
             env->CallBooleanMethod(droppedPaths, listAddMethod, javaPath);
             env->DeleteLocalRef(javaPath);
+            getJavaExceptionAndPrintStacktrace(env);
 
             it->cancel();
         }

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -12,7 +12,8 @@ using namespace std;
 WatchPoint::WatchPoint(Server* server, size_t eventBufferSize, const wstring& path)
     : pathW(path)
     , path(u16string(path.begin(), path.end()))
-    , status(WatchPointStatus::NOT_LISTENING) {
+    , status(WatchPointStatus::NOT_LISTENING)
+    , server(server) {
     HANDLE directoryHandle = CreateFileW(
         pathW.c_str(),          // pointer to the file name
         FILE_LIST_DIRECTORY,    // access (read/write) mode
@@ -26,8 +27,6 @@ WatchPoint::WatchPoint(Server* server, size_t eventBufferSize, const wstring& pa
         throw FileWatcherException("Couldn't add watch", this->path, GetLastError());
     }
     this->directoryHandle = directoryHandle;
-
-    this->server = server;
     this->eventBuffer.reserve(eventBufferSize);
     ZeroMemory(&this->overlapped, sizeof(OVERLAPPED));
     this->overlapped.hEvent = this;

--- a/file-events/src/file-events/headers/generic_fsnotifier.h
+++ b/file-events/src/file-events/headers/generic_fsnotifier.h
@@ -44,6 +44,8 @@ public:
 
 class AbstractServer;
 
+AbstractServer* getServer(JNIEnv* env, jobject javaServer);
+
 class AbstractServer : public JniSupport {
 public:
     AbstractServer(JNIEnv* env, jobject watcherCallback);

--- a/file-events/src/file-events/headers/jni_support.h
+++ b/file-events/src/file-events/headers/jni_support.h
@@ -7,6 +7,19 @@
 
 using namespace std;
 
+// Utility wrapper to adapt locale-bound facets for wstring convert
+// Exposes the protected destructor as public
+// See https://en.cppreference.com/w/cpp/locale/codecvt
+template <class Facet>
+struct deletable_facet : Facet {
+    template <class... Args>
+    deletable_facet(Args&&... args)
+        : Facet(forward<Args>(args)...) {
+    }
+    ~deletable_facet() {
+    }
+};
+
 template <typename T>
 class JniGlobalRef;
 

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -64,6 +64,11 @@ public:
 
     ListenResult listen();
     bool cancel();
+    /**
+     * Returns the path that is being watched. If the watched handle has been moved,
+     * this returns the new path.
+     */
+    wstring getPath();
 
 private:
     bool isValidDirectory();
@@ -108,7 +113,6 @@ private:
     unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
-    vector<wchar_t> stringBuffer;
 };
 
 #endif

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -13,6 +13,7 @@
 // Needs to stay below <windows.h> otherwise byte symbol gets confused with std::byte
 #include "generic_fsnotifier.h"
 #include "net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions.h"
+#include "net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_WindowsFileWatcher.h"
 
 using namespace std;
 
@@ -90,6 +91,9 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, size_t eventBufferSize, long commandTimeoutInMillis, jobject watcherCallback);
 
+    // List<String> droppedPaths
+    void stopWatchingMovedPaths(jobject droppedPaths);
+
     void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& eventBuffer, DWORD bytesTransferred);
     bool executeOnRunLoop(function<bool()> command);
 
@@ -113,6 +117,7 @@ private:
     list<WatchPoint> watchPoints;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
+    jmethodID listAddMethod;
 };
 
 #endif

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -75,7 +75,7 @@ private:
     void close();
 
     Server* server;
-    const wstring path;
+    const wstring registeredPath;
     friend class Server;
     HANDLE directoryHandle;
     OVERLAPPED overlapped;

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -59,7 +59,7 @@ enum class WatchPointStatus {
 
 class WatchPoint {
 public:
-    WatchPoint(Server* server, size_t bufferSize, const wstring& path);
+    WatchPoint(Server* server, size_t eventBufferSize, const wstring& path);
     ~WatchPoint();
 
     ListenResult listen();
@@ -75,7 +75,7 @@ private:
     friend class Server;
     HANDLE directoryHandle;
     OVERLAPPED overlapped;
-    vector<BYTE> buffer;
+    vector<BYTE> eventBuffer;
     WatchPointStatus status;
 
     void handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred);
@@ -84,9 +84,9 @@ private:
 
 class Server : public AbstractServer {
 public:
-    Server(JNIEnv* env, size_t bufferSize, long commandTimeoutInMillis, jobject watcherCallback);
+    Server(JNIEnv* env, size_t eventBufferSize, long commandTimeoutInMillis, jobject watcherCallback);
 
-    void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& buffer, DWORD bytesTransferred);
+    void handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& eventBuffer, DWORD bytesTransferred);
     bool executeOnRunLoop(function<bool()> command);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
@@ -104,7 +104,7 @@ private:
     bool unregisterPath(const u16string& path);
 
     HANDLE threadHandle;
-    const size_t bufferSize;
+    const size_t eventBufferSize;
     const long commandTimeoutInMillis;
     unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -5,7 +5,7 @@
 #include <Shlwapi.h>
 #include <functional>
 #include <string>
-#include <unordered_map>
+#include <list>
 #include <vector>
 #include <wchar.h>
 #include <windows.h>
@@ -110,7 +110,7 @@ private:
     HANDLE threadHandle;
     const size_t eventBufferSize;
     const long commandTimeoutInMillis;
-    unordered_map<wstring, WatchPoint> watchPoints;
+    list<WatchPoint> watchPoints;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
 };

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -108,6 +108,7 @@ private:
     unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
+    vector<wchar_t> stringBuffer;
 };
 
 #endif

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -59,7 +59,7 @@ enum class WatchPointStatus {
 
 class WatchPoint {
 public:
-    WatchPoint(Server* server, size_t bufferSize, const u16string& path);
+    WatchPoint(Server* server, size_t bufferSize, const wstring& path);
     ~WatchPoint();
 
     ListenResult listen();
@@ -70,6 +70,7 @@ private:
     void close();
 
     Server* server;
+    const wstring pathW;
     const u16string path;
     friend class Server;
     HANDLE directoryHandle;
@@ -97,7 +98,7 @@ protected:
     void shutdownRunLoop() override;
 
 private:
-    void handleEvent(JNIEnv* env, const u16string& path, FILE_NOTIFY_EXTENDED_INFORMATION* info);
+    void handleEvent(JNIEnv* env, const wstring& watchedPath, FILE_NOTIFY_EXTENDED_INFORMATION* info);
 
     void registerPath(const u16string& path);
     bool unregisterPath(const u16string& path);
@@ -105,7 +106,7 @@ private:
     HANDLE threadHandle;
     const size_t bufferSize;
     const long commandTimeoutInMillis;
-    unordered_map<u16string, WatchPoint> watchPoints;
+    unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;
     friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
 };

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -71,7 +71,6 @@ private:
 
     Server* server;
     const wstring pathW;
-    const u16string path;
     friend class Server;
     HANDLE directoryHandle;
     OVERLAPPED overlapped;

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -70,7 +70,7 @@ private:
     void close();
 
     Server* server;
-    const wstring pathW;
+    const wstring path;
     friend class Server;
     HANDLE directoryHandle;
     OVERLAPPED overlapped;

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public abstract class AbstractFileEventFunctions implements NativeIntegration {
+public abstract class AbstractFileEventFunctions<W extends FileWatcher> implements NativeIntegration {
     public static String getVersion() {
         return getVersion0();
     }
@@ -81,7 +81,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
      * The queue must have a total capacity of at least 2 elements.
      * The caller should only consume events from the queue, and never add any of their own.
      */
-    public abstract AbstractWatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> queue);
+    public abstract AbstractWatcherBuilder<W> newWatcher(BlockingQueue<FileWatchEvent> queue);
 
     protected static class NativeFileWatcherCallback {
 

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -32,7 +32,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
 
     private native void invalidateLogLevelCache0();
 
-    public abstract static class AbstractWatcherBuilder {
+    public abstract static class AbstractWatcherBuilder<T extends FileWatcher> {
         public static final long DEFAULT_START_TIMEOUT_IN_SECONDS = 5;
 
         private final BlockingQueue<FileWatchEvent> eventQueue;
@@ -50,7 +50,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
          *
          * @see FileWatcher#startWatching(Collection)
          */
-        public FileWatcher start() throws InterruptedException {
+        public T start() throws InterruptedException {
             return start(DEFAULT_START_TIMEOUT_IN_SECONDS, SECONDS);
         }
 
@@ -63,13 +63,15 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
          *
          * @see FileWatcher#startWatching(Collection)
          */
-        public FileWatcher start(long startTimeout, TimeUnit startTimeoutUnit) throws InterruptedException, InsufficientResourcesForWatchingException {
+        public T start(long startTimeout, TimeUnit startTimeoutUnit) throws InterruptedException, InsufficientResourcesForWatchingException {
             NativeFileWatcherCallback callback = new NativeFileWatcherCallback(eventQueue);
             Object server = startWatcher(callback);
-            return new NativeFileWatcher(server, startTimeout, startTimeoutUnit, callback);
+            return createWatcher(server, startTimeout, startTimeoutUnit, callback);
         }
 
         protected abstract Object startWatcher(NativeFileWatcherCallback callback);
+
+        protected abstract T createWatcher(final Object server, long startTimeout, TimeUnit startTimeoutUnit, final NativeFileWatcherCallback callback) throws InterruptedException;
     }
 
     /**
@@ -154,7 +156,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
         }
     }
 
-    protected static class NativeFileWatcher implements FileWatcher {
+    protected static abstract class NativeFileWatcher implements FileWatcher {
         private final Object server;
         private final Thread processorThread;
         private boolean shutdown;

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -157,7 +157,7 @@ public abstract class AbstractFileEventFunctions implements NativeIntegration {
     }
 
     protected static abstract class NativeFileWatcher implements FileWatcher {
-        private final Object server;
+        protected final Object server;
         private final Thread processorThread;
         private boolean shutdown;
 

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -21,6 +21,7 @@ import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 /**
  * File watcher for Linux. Reports changes to the watched paths and their immediate children.
@@ -52,7 +53,13 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
         return new WatcherBuilder(eventQueue);
     }
 
-    public static class WatcherBuilder extends AbstractWatcherBuilder {
+    public static class LinuxFileWatcher extends NativeFileWatcher {
+        public LinuxFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
+            super(server, startTimeout, startTimeoutUnit, callback);
+        }
+    }
+
+    public static class WatcherBuilder extends AbstractWatcherBuilder<LinuxFileWatcher> {
         WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
             super(eventQueue);
         }
@@ -60,6 +67,11 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
         @Override
         protected Object startWatcher(NativeFileWatcherCallback callback) throws InotifyInstanceLimitTooLowException {
             return startWatcher0(callback);
+        }
+
+        @Override
+        protected LinuxFileWatcher createWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
+            return new LinuxFileWatcher(server, startTimeout, startTimeoutUnit, callback);
         }
     }
 

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  *     behavior and can lead to a deadlock.</li>
  * </ul>
  */
-public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
+public class LinuxFileEventFunctions extends AbstractFileEventFunctions<LinuxFileEventFunctions.LinuxFileWatcher> {
 
     public LinuxFileEventFunctions() {
         // We have seen some weird behavior on Alpine Linux that uses musl with Gradle that lead to crashes
@@ -53,7 +53,7 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions {
         return new WatcherBuilder(eventQueue);
     }
 
-    public static class LinuxFileWatcher extends NativeFileWatcher {
+    public static class LinuxFileWatcher extends AbstractFileEventFunctions.NativeFileWatcher {
         public LinuxFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
             super(server, startTimeout, startTimeoutUnit, callback);
         }

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  *     behavior and can lead to a deadlock.</li>
  * </ul>
  */
-public class OsxFileEventFunctions extends AbstractFileEventFunctions {
+public class OsxFileEventFunctions extends AbstractFileEventFunctions<OsxFileEventFunctions.OsxFileWatcher> {
     private static final long DEFAULT_LATENCY_IN_MS = 0;
 
     @Override
@@ -49,7 +49,7 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
         return new WatcherBuilder(eventQueue);
     }
 
-    public static class OsxFileWatcher extends NativeFileWatcher {
+    public static class OsxFileWatcher extends AbstractFileEventFunctions.NativeFileWatcher {
         public OsxFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
             super(server, startTimeout, startTimeoutUnit, callback);
         }

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxFileEventFunctions.java
@@ -49,7 +49,13 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
         return new WatcherBuilder(eventQueue);
     }
 
-    public static class WatcherBuilder extends AbstractWatcherBuilder {
+    public static class OsxFileWatcher extends NativeFileWatcher {
+        public OsxFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
+            super(server, startTimeout, startTimeoutUnit, callback);
+        }
+    }
+
+    public static class WatcherBuilder extends AbstractWatcherBuilder<OsxFileWatcher> {
         private long latencyInMillis = DEFAULT_LATENCY_IN_MS;
 
         WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
@@ -71,6 +77,11 @@ public class OsxFileEventFunctions extends AbstractFileEventFunctions {
         @Override
         protected Object startWatcher(NativeFileWatcherCallback callback) {
             return startWatcher0(latencyInMillis, callback);
+        }
+
+        @Override
+        protected OsxFileWatcher createWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
+            return new OsxFileWatcher(server, startTimeout, startTimeoutUnit, callback);
         }
     }
 

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -19,7 +19,10 @@ package net.rubygrapefruit.platform.internal.jni;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -57,6 +60,22 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
         public WindowsFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
             super(server, startTimeout, startTimeoutUnit, callback);
         }
+
+        /**
+         * Stops watching any directory hierarchies that have been moved to a different path since registration,
+         * and returns the list of the registered paths that have been dropped.
+         */
+        public List<File> stopWatchingMovedPaths() {
+            List<String> droppedPathStrings = new ArrayList<String>();
+            stopWatchingMovedPaths0(server, droppedPathStrings);
+            List<File> droppedPaths = new ArrayList<File>(droppedPathStrings.size());
+            for (String droppedPath : droppedPathStrings) {
+                droppedPaths.add(new File(droppedPath));
+            }
+            return droppedPaths;
+        }
+
+        private native void stopWatchingMovedPaths0(Object server, List<String> droppedPaths);
     }
 
     public static class WatcherBuilder extends AbstractWatcherBuilder<WindowsFileWatcher> {

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -53,7 +53,13 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
         return new WatcherBuilder(eventQueue);
     }
 
-    public static class WatcherBuilder extends AbstractWatcherBuilder {
+    public static class WindowsFileWatcher extends NativeFileWatcher {
+        public WindowsFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
+            super(server, startTimeout, startTimeoutUnit, callback);
+        }
+    }
+
+    public static class WatcherBuilder extends AbstractWatcherBuilder<WindowsFileWatcher> {
         private int bufferSize = DEFAULT_BUFFER_SIZE;
         private long commandTimeoutInMillis = TimeUnit.SECONDS.toMillis(DEFAULT_COMMAND_TIMEOUT_IN_SECONDS);
 
@@ -88,6 +94,11 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
         @Override
         protected Object startWatcher(NativeFileWatcherCallback callback) {
             return startWatcher0(bufferSize, commandTimeoutInMillis, callback);
+        }
+
+        @Override
+        protected WindowsFileWatcher createWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
+            return new WindowsFileWatcher(server, startTimeout, startTimeoutUnit, callback);
         }
     }
 

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileEventFunctions.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  *     behavior and can lead to a deadlock.</li>
  * </ul>
  */
-public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
+public class WindowsFileEventFunctions extends AbstractFileEventFunctions<WindowsFileEventFunctions.WindowsFileWatcher> {
 
     public static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
     public static final int DEFAULT_COMMAND_TIMEOUT_IN_SECONDS = 5;
@@ -56,7 +56,7 @@ public class WindowsFileEventFunctions extends AbstractFileEventFunctions {
         return new WatcherBuilder(eventQueue);
     }
 
-    public static class WindowsFileWatcher extends NativeFileWatcher {
+    public static class WindowsFileWatcher extends AbstractFileEventFunctions.NativeFileWatcher {
         public WindowsFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
             super(server, startTimeout, startTimeoutUnit, callback);
         }

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -838,7 +838,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         // Restart watching freshly recreated directory on platforms that auto-unregister on deletion
         if (!Platform.current().macOs) {
-            watcher.startWatching(watchedDir)
+            watcher.startWatching([watchedDir])
         }
         // Ignore events received during setup
         waitForChangeEventLatency()

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -850,4 +850,22 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         then:
         expectEvents change(CREATED, createdFile)
     }
+
+    @Requires({ Platform.current().windows })
+    def "reports events in new location when watched directory has been moved"() {
+        given:
+        def watchedDir = new File(rootDir, "watched")
+        assert watchedDir.mkdirs()
+        def renamedDir = new File(rootDir, "renamed")
+        def createdFile = new File(renamedDir, "created.txt")
+        startWatcher(watchedDir)
+
+        watchedDir.renameTo(renamedDir)
+
+        when:
+        createdFile.createNewFile()
+
+        then:
+        expectEvents change(CREATED, createdFile)
+    }
 }

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -467,7 +467,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         startWatcher(rootDir)
 
         when:
-        watcher.startWatching(rootDir)
+        startWatching(rootDir)
 
         then:
         def ex = thrown NativeException
@@ -481,7 +481,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         startWatcher()
 
         expect:
-        !watcher.stopWatching(rootDir)
+        !stopWatching(rootDir)
 
         expectLogMessage(INFO, "Path is not watched: ${rootDir.absolutePath}")
     }
@@ -489,10 +489,10 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
     def "can un-watch watched directory twice"() {
         given:
         startWatcher(rootDir)
-        watcher.stopWatching(rootDir)
 
         expect:
-        !watcher.stopWatching(rootDir)
+        stopWatching(rootDir)
+        !stopWatching(rootDir)
 
         expectLogMessage(INFO, "Path is not watched: ${rootDir.absolutePath}")
     }
@@ -503,7 +503,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         startWatcher(rootDir)
 
         expect:
-        watcher.stopWatching(rootDir)
+        stopWatching(rootDir)
 
         when:
         createNewFile(file)
@@ -611,10 +611,10 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         LOGGER.info("> Starting first watcher")
         def firstWatcher = startNewWatcher(firstQueue)
-        firstWatcher.startWatching(firstRoot)
+        firstWatcher.startWatching([firstRoot])
         LOGGER.info("> Starting second watcher")
         def secondWatcher = startNewWatcher(secondQueue)
-        secondWatcher.startWatching(secondRoot)
+        secondWatcher.startWatching([secondRoot])
         LOGGER.info("> Watchers started")
 
         when:

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -544,23 +544,19 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         def fileInUppercaseDir = new File(uppercaseDir, "UPPERCASE.TXT")
         uppercaseDir.mkdirs()
 
-        def reportedDir = Platform.current().macOs
-            ? uppercaseDir
-            : lowercaseDir
-
         startWatcher(lowercaseDir)
 
         when:
         createNewFile(fileInLowercaseDir)
 
         then:
-        expectEvents change(CREATED, new File(reportedDir, fileInLowercaseDir.name))
+        expectEvents change(CREATED, new File(uppercaseDir, fileInLowercaseDir.name))
 
         when:
         createNewFile(fileInUppercaseDir)
 
         then:
-        expectEvents change(CREATED, new File(reportedDir, fileInUppercaseDir.name))
+        expectEvents change(CREATED, new File(uppercaseDir, fileInUppercaseDir.name))
     }
 
     def "fails when stopped multiple times"() {

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -868,4 +868,28 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         then:
         expectEvents change(CREATED, createdFile)
     }
+
+    @Requires({ Platform.current().windows })
+    def "drops moved locations"() {
+        given:
+        def watchedDir = new File(rootDir, "watched")
+        assert watchedDir.mkdirs()
+        def renamedDir = new File(rootDir, "renamed")
+        def createdFile = new File(renamedDir, "created.txt")
+        startWatcher(watchedDir)
+
+        watchedDir.renameTo(renamedDir)
+
+        when:
+        def droppedPaths = watcher.stopWatchingMovedPaths()
+
+        then:
+        droppedPaths == [watchedDir]
+
+        when:
+        createdFile.createNewFile()
+
+        then:
+        expectNoEvents()
+    }
 }

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/FileEventFunctionsStressTest.groovy
@@ -53,8 +53,8 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         def createdFile = new File(rootDir, "created.txt")
         startWatcher(rootDir)
         100.times {
-            assert watcher.stopWatching(rootDir)
-            watcher.startWatching(rootDir)
+            assert stopWatching(rootDir)
+            startWatching(rootDir)
         }
 
         when:
@@ -72,8 +72,8 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         when:
         100.times { iteration ->
-            watcher.startWatching(watchedDirs)
-            assert watcher.stopWatching(watchedDirs)
+            startWatching(watchedDirs)
+            assert stopWatching(watchedDirs)
         }
 
         then:
@@ -196,7 +196,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
         List<File> watchedDirectories = createHierarchy(watchedDir, watchedDirectoryDepth)
         def watcher = startNewWatcher()
         def onslaught = new OnslaughtExecutor(watchedDirectories.collect { watchedDirectory ->
-            return { -> watcher.stopWatching(watchedDirectory) } as Runnable
+            return { -> watcher.stopWatching([watchedDirectory]) } as Runnable
         })
 
         onslaught.awaitReady()
@@ -271,7 +271,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         def stopWatchingJobs = watchedDirectories.collect { dir ->
             return {
-                watcher.stopWatching(dir)
+                watcher.stopWatching([dir])
             } as Runnable
         }
         def deleteDirectoriesJobs = watchedDirectories.collect { dir ->
@@ -304,7 +304,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
 
         when:
         def watcher = startNewWatcher()
-        watcher.startWatching(watchedDir)
+        watcher.startWatching([watchedDir])
         waitForChangeEventLatency()
         assert watchedDir.deleteDir()
         shutdownWatcher(watcher)
@@ -314,7 +314,7 @@ class FileEventFunctionsStressTest extends AbstractFileEventFunctionsTest {
     }
 
     @Override
-    protected TestFileWatcher startNewWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
+    protected FileWatcher startNewWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
         // Make sure we don't receive overflow events during these tests
         return watcherFixture.startNewWatcherWithOverflowPrevention(eventQueue)
     }

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/SymlinkFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/SymlinkFileEventFunctionsTest.groovy
@@ -23,6 +23,7 @@ import spock.lang.Requires
 import spock.lang.Unroll
 
 import static java.nio.file.Files.createSymbolicLink
+import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.LINUX
 import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.MAC_OS
 import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.OTHERWISE
 import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.WINDOWS
@@ -120,8 +121,8 @@ class SymlinkFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         expectEvents byPlatform(
-            (MAC_OS): [change(MODIFIED, canonicalFile)],
-            (OTHERWISE): [change(MODIFIED, watchedFile)]
+            (LINUX): [change(MODIFIED, watchedFile)],
+            (OTHERWISE): [change(MODIFIED, canonicalFile)]
         )
     }
 
@@ -141,8 +142,8 @@ class SymlinkFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         expectEvents byPlatform(
-            (MAC_OS): [change(MODIFIED, canonicalFile)],
-            (OTHERWISE): [change(MODIFIED, watchedFile)]
+            (LINUX): [change(MODIFIED, watchedFile)],
+            (OTHERWISE): [change(MODIFIED, canonicalFile)]
         )
     }
 
@@ -163,8 +164,8 @@ class SymlinkFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         expectEvents byPlatform(
-            (MAC_OS): [change(MODIFIED, canonicalFile), change(MODIFIED, canonicalFile)],
-            (OTHERWISE): [change(MODIFIED, linkedFile), change(MODIFIED, canonicalFile)]
+            (LINUX): [change(MODIFIED, linkedFile), change(MODIFIED, canonicalFile)],
+            (OTHERWISE): [change(MODIFIED, canonicalFile), change(MODIFIED, canonicalFile)]
         )
     }
 


### PR DESCRIPTION
Windows handles file watching using relative paths. When the watched directory is moved, Windows sends no notification. A client keeping track of absolute paths faces two problems:

1) when changes are made to the contents of the moved directory, changes are still reported as if they happened under the original, registered root,
2) there is no way to know if the original location has completely disappeared due to a move.

(Note that if the original watched root is deleted, Windows does send a notification, so this is just about renames/moves.)

The problems are addressed in this PR as follows:

1) we are now reporting the moved locations for further changes,
2) while we still can't get notified about the original location being moved away, there is now a new API (`WindowsFileWatcher.stopWatchingMovedLocations()`) that can be used to stop watching any locations that have been moved since registration. The new API returns the _originally registered path_ of all stopped watch points.

The PR also includes the following changes:

- it exposes platform-specific `FileWatcher` implementations to allow for the Windows-specific functionality to be accessed,
- Windows paths are now handled as `wstring`s,
- we keep track of the registered watchers as a `std::list` instead of `std::unordered_map` to reduce potentially stale path references. (We still keep the originally registered path in the `WatchPoint` instance.)