### PR TITLE
Fix flaky test on Windows

### DIFF
--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -714,7 +714,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         } else if (Platform.current().linux) {
             expectedEvents << change(REMOVED, removedFile) << change(REMOVED, watchedDir)
         } else if (Platform.current().windows) {
-            expectedEvents << change(MODIFIED, removedFile) << change(REMOVED, removedFile) << change(REMOVED, watchedDir)
+            expectedEvents << change(MODIFIED, removedFile) << optionalChange(REMOVED, removedFile) << change(REMOVED, watchedDir)
         }
 
         then:


### PR DESCRIPTION
It seems that when removing the whole watched hierarchy, the deleted files are not always reported as removed (only modified). This has been the case before we switched to `ReadDirectoryChangesExW()` in #287, so we are just reverting to testing the original behavior here.