### PR TITLE
Handle moved watched handles on Windows more resiliently

### DIFF
--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -142,18 +142,21 @@ WatchPoint::~WatchPoint() {
 // Allocate maximum path length
 #define PATH_BUFFER_SIZE 32768
 
-wstring WatchPoint::getPath() {
+bool WatchPoint::getPath(wstring& path) {
     vector<wchar_t> buffer;
     buffer.reserve(PATH_BUFFER_SIZE);
     DWORD pathLength = GetFinalPathNameByHandleW(
-        this->directoryHandle,
+        directoryHandle,
         &buffer[0],
         PATH_BUFFER_SIZE,
         FILE_NAME_OPENED);
     if (pathLength == 0 || pathLength > PATH_BUFFER_SIZE) {
-        throw FileWatcherException("Error received when resolving file path", GetLastError());
+        logToJava(LogLevel::WARNING, "Couldn't look up handle 0x%x, error code: %d", directoryHandle, GetLastError());
+        return false;
     }
-    return wstring(&buffer[0], 0, pathLength);
+    path.clear();
+    path.insert(0, &buffer[0], pathLength);
+    return true;
 }
 
 static void CALLBACK handleEventCallback(DWORD errorCode, DWORD bytesTransferred, LPOVERLAPPED overlapped) {
@@ -231,19 +234,25 @@ void WatchPoint::handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred) {
 
 void Server::handleEvents(WatchPoint* watchPoint, DWORD errorCode, const vector<BYTE>& eventBuffer, DWORD bytesTransferred) {
     JNIEnv* env = getThreadEnv();
-    wstring path = watchPoint->getPath();
-    convertFromLongPathIfNeeded(path);
 
     try {
         if (errorCode != ERROR_SUCCESS) {
             if (errorCode == ERROR_ACCESS_DENIED && !watchPoint->isValidDirectory()) {
-                reportChangeEvent(env, ChangeType::REMOVED, wideToUtf16String(path));
-                watchPoint->close();
+                reportWatchPointDeleted(watchPoint);
                 return;
             } else {
-                throw FileWatcherException("Error received when handling events", wideToUtf16String(path), errorCode);
+                throw FileWatcherException("Error received when handling events", wideToUtf16String(watchPoint->registeredPath), errorCode);
             }
         }
+
+        wstring path;
+        bool watchedHandleIsAccessible = watchPoint->getPath(path);
+        if (!watchedHandleIsAccessible) {
+            // The handle has become invalid or missing, consider this as if the the watch point was deleted
+            reportWatchPointDeleted(watchPoint);
+            return;
+        }
+        convertFromLongPathIfNeeded(path);
 
         if (shouldTerminate) {
             logToJava(LogLevel::FINE, "Ignoring incoming events for %s because server is terminating (%d bytes, status = %d)",
@@ -319,9 +328,10 @@ void Server::handleEvent(JNIEnv* env, const wstring& watchedPathW, FILE_NOTIFY_E
     reportChangeEvent(env, type, wideToUtf16String(changedPathW));
 }
 
-//
-// Server
-//
+void Server::reportWatchPointDeleted(WatchPoint* watchPoint) {
+    reportChangeEvent(getThreadEnv(), ChangeType::REMOVED, wideToUtf16String(watchPoint->registeredPath));
+    watchPoint->close();
+}
 
 Server::Server(JNIEnv* env, size_t eventBufferSize, long commandTimeoutInMillis, jobject watcherCallback)
     : AbstractServer(env, watcherCallback)
@@ -459,7 +469,9 @@ void Server::stopWatchingMovedPaths(jobject droppedPaths) {
             continue;
         }
         wstring registeredPath = it->registeredPath;
-        if (registeredPath != it->getPath()) {
+        wstring watchedPath;
+        bool watchedHandleIsAccessible = it->getPath(watchedPath);
+        if (!watchedHandleIsAccessible || registeredPath != watchedPath) {
             convertFromLongPathIfNeeded(registeredPath);
 
             jstring javaPath = env->NewString((jchar*) wideToUtf16String(registeredPath).c_str(), (jsize) registeredPath.length());

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -455,6 +455,9 @@ bool Server::unregisterPath(const u16string& path) {
 void Server::stopWatchingMovedPaths(jobject droppedPaths) {
     JNIEnv* env = getThreadEnv();
     for (auto it = watchPoints.begin(); it != watchPoints.end(); ++it) {
+        if (it->status == WatchPointStatus::FINISHED) {
+            continue;
+        }
         wstring registeredPath = it->registeredPath;
         if (registeredPath != it->getPath()) {
             convertFromLongPathIfNeeded(registeredPath);

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -66,10 +66,10 @@ public:
     ListenResult listen();
     bool cancel();
     /**
-     * Returns the path that is being watched. If the watched handle has been moved,
-     * this returns the new path.
+     * Gets the path currently associated with the watched handle. Returns false
+     * if it failed to set the path becuase the handle was somehow inaccessible.
      */
-    wstring getPath();
+    bool getPath(wstring& path);
 
 private:
     bool isValidDirectory();
@@ -110,6 +110,8 @@ private:
 
     void registerPath(const u16string& path);
     bool unregisterPath(const u16string& path);
+
+    void reportWatchPointDeleted(WatchPoint* watchPoint);
 
     HANDLE threadHandle;
     const size_t eventBufferSize;

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -67,7 +67,7 @@ public:
     bool cancel();
     /**
      * Gets the path currently associated with the watched handle. Returns false
-     * if it failed to set the path becuase the handle was somehow inaccessible.
+     * if it failed to set the path because the handle was somehow inaccessible.
      */
     bool getPath(wstring& path);
 

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -882,14 +882,17 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         when:
         def droppedPaths = watcher.stopWatchingMovedPaths()
-
         then:
         droppedPaths == [watchedDir]
 
         when:
         createdFile.createNewFile()
-
         then:
         expectNoEvents()
+
+        when:
+        droppedPaths = watcher.stopWatchingMovedPaths()
+        then:
+        droppedPaths == []
     }
 }


### PR DESCRIPTION
There is a bug where we re-check already `FINISHED` watch points in `stopWatchingMovedPaths()`. We should also handle the case when `getPath()` fails for whatever reason.