### PR TITLE
Allow checking for moved paths on Linux

### DIFF
--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -288,7 +288,7 @@ void Server::registerPath(const u16string& path) {
     string pathNarrow = utf16ToUtf8String(path);
     struct stat st;
     if (lstat(pathNarrow.c_str(), &st) != 0) {
-        throw FileWatcherException("Couldn't stat path", path, errno);
+        throw FileWatcherException("Couldn't add watch, stat failed", path, errno);
     }
 
     int watchDescriptor = inotify_add_watch(inotify->fd, pathNarrow.c_str(), EVENT_MASK);
@@ -297,7 +297,7 @@ void Server::registerPath(const u16string& path) {
             rethrowAsJavaException(getThreadEnv(), InotifyWatchesLimitTooLowException(), linuxJniConstants->inotifyWatchesLimitTooLowExceptionClass.get());
             throw JavaExceptionThrownException();
         }
-        throw FileWatcherException("Couldn't add watch", path, errno);
+        throw FileWatcherException("Couldn't add watch, inotify_add_watch failed", path, errno);
     }
     if (watchRoots.find(watchDescriptor) != watchRoots.end()) {
         throw FileWatcherException("Already watching path", path);

--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -330,7 +330,7 @@ bool Server::unregisterPath(const u16string& path) {
     return ret == CancelResult::CANCELLED;
 }
 
-void Server::stopWatchingMovedPaths(vector<u16string> absolutePathsToCheck, jobject droppedPaths) {
+void Server::stopWatchingMovedPaths(const vector<u16string>& absolutePathsToCheck, jobject droppedPaths) {
     JNIEnv* env = getThreadEnv();
     for (auto& pathToCheck : absolutePathsToCheck) {
         auto it = watchPoints.find(pathToCheck);

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -120,7 +120,7 @@ WatchPoint::WatchPoint(Server* server, size_t eventBufferSize, const wstring& pa
         case ListenResult::SUCCESS:
             break;
         case ListenResult::DELETED:
-            throw FileWatcherException("Couldn't start watching because path is not a directory", wideToUtf16String(path));
+            throw FileWatcherException("Couldn't add watch, path is not a directory", wideToUtf16String(path));
     }
 }
 
@@ -187,7 +187,7 @@ ListenResult WatchPoint::listen() {
         if (listenError == ERROR_ACCESS_DENIED && !isValidDirectory()) {
             return ListenResult::DELETED;
         } else {
-            throw FileWatcherException("Couldn't start watching", wideToUtf16String(registeredPath), listenError);
+            throw FileWatcherException("Couldn't add watch", wideToUtf16String(registeredPath), listenError);
         }
     }
 }

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -93,7 +93,7 @@ public:
     Server(JNIEnv* env, jobject watcherCallback);
 
     // List<String> droppedPaths
-    void stopWatchingMovedPaths(vector<u16string> absolutePathsToCheck, jobject droppedPaths);
+    void stopWatchingMovedPaths(const vector<u16string>& absolutePathsToCheck, jobject droppedPaths);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
     virtual bool unregisterPaths(const vector<u16string>& paths) override;

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -10,6 +10,7 @@
 
 #include "generic_fsnotifier.h"
 #include "net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions.h"
+#include "net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_LinuxFileWatcher.h"
 
 using namespace std;
 
@@ -91,6 +92,9 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback);
 
+    // List<String> droppedPaths
+    void stopWatchingMovedPaths(jobject droppedPaths);
+
     virtual void registerPaths(const vector<u16string>& paths) override;
     virtual bool unregisterPaths(const vector<u16string>& paths) override;
 
@@ -115,6 +119,7 @@ private:
     const ShutdownEvent shutdownEvent;
     bool shouldTerminate = false;
     vector<uint8_t> buffer;
+    jmethodID listAddMethod;
 };
 
 class LinuxJniConstants : public JniSupport {

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -5,6 +5,7 @@
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <sys/inotify.h>
+#include <sys/stat.h>
 #include <unordered_map>
 
 #include "generic_fsnotifier.h"
@@ -72,7 +73,7 @@ enum class CancelResult {
 
 class WatchPoint {
 public:
-    WatchPoint(const u16string& path, const shared_ptr<Inotify> inotify, int watchDescriptor);
+    WatchPoint(const u16string& path, const shared_ptr<Inotify> inotify, int watchDescriptor, ino_t inode);
 
     CancelResult cancel();
 
@@ -81,6 +82,7 @@ private:
     const int watchDescriptor;
     const shared_ptr<Inotify> inotify;
     const u16string path;
+    const ino_t inode;
 
     friend class Server;
 };

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -93,7 +93,7 @@ public:
     Server(JNIEnv* env, jobject watcherCallback);
 
     // List<String> droppedPaths
-    void stopWatchingMovedPaths(jobject droppedPaths);
+    void stopWatchingMovedPaths(vector<u16string> absolutePathsToCheck, jobject droppedPaths);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
     virtual bool unregisterPaths(const vector<u16string>& paths) override;

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -208,7 +208,7 @@ public abstract class AbstractFileEventFunctions<W extends FileWatcher> implemen
 
         private native boolean stopWatching0(Object server, String[] absolutePaths);
 
-        private static String[] toAbsolutePaths(Collection<File> files) {
+        protected static String[] toAbsolutePaths(Collection<File> files) {
             String[] paths = new String[files.size()];
             int index = 0;
             for (File file : files) {

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -22,6 +22,7 @@ import net.rubygrapefruit.platform.file.FileWatcher;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -65,9 +66,10 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions<LinuxFil
          * Stops watching any directories that have been moved to a different path since registration,
          * and returns the list of the registered paths that have been dropped.
          */
-        public List<File> stopWatchingMovedPaths() {
+        public List<File> stopWatchingMovedPaths(Collection<File> pathsToCheck) {
+            String[] absolutePathsToCheck = toAbsolutePaths(pathsToCheck);
             List<String> droppedPathStrings = new ArrayList<String>();
-            stopWatchingMovedPaths0(server, droppedPathStrings);
+            stopWatchingMovedPaths0(server, absolutePathsToCheck, droppedPathStrings);
             List<File> droppedPaths = new ArrayList<File>(droppedPathStrings.size());
             for (String droppedPath : droppedPathStrings) {
                 droppedPaths.add(new File(droppedPath));
@@ -75,7 +77,7 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions<LinuxFil
             return droppedPaths;
         }
 
-        private native void stopWatchingMovedPaths0(Object server, List<String> droppedPaths);
+        private native void stopWatchingMovedPaths0(Object server, String[] absolutePathsToCheck, List<String> droppedPaths);
     }
 
     public static class WatcherBuilder extends AbstractWatcherBuilder<LinuxFileWatcher> {

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/LinuxFileEventFunctions.java
@@ -20,6 +20,9 @@ import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -57,6 +60,22 @@ public class LinuxFileEventFunctions extends AbstractFileEventFunctions<LinuxFil
         public LinuxFileWatcher(Object server, long startTimeout, TimeUnit startTimeoutUnit, NativeFileWatcherCallback callback) throws InterruptedException {
             super(server, startTimeout, startTimeoutUnit, callback);
         }
+
+        /**
+         * Stops watching any directories that have been moved to a different path since registration,
+         * and returns the list of the registered paths that have been dropped.
+         */
+        public List<File> stopWatchingMovedPaths() {
+            List<String> droppedPathStrings = new ArrayList<String>();
+            stopWatchingMovedPaths0(server, droppedPathStrings);
+            List<File> droppedPaths = new ArrayList<File>(droppedPathStrings.size());
+            for (String droppedPath : droppedPathStrings) {
+                droppedPaths.add(new File(droppedPath));
+            }
+            return droppedPaths;
+        }
+
+        private native void stopWatchingMovedPaths0(Object server, List<String> droppedPaths);
     }
 
     public static class WatcherBuilder extends AbstractWatcherBuilder<LinuxFileWatcher> {

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -440,9 +440,9 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         then:
         def ex = thrown NativeException
-        ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/
+        ex.message ==~ /Couldn't stat path.*: ${Pattern.quote(missingDirectory.absolutePath)}/
 
-        expectLogMessage(SEVERE, Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
+        expectLogMessage(SEVERE, Pattern.compile("Caught exception: Couldn't stat path.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
     }
 
     // Apparently on macOS we can watch files
@@ -451,6 +451,7 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
     def "fails when watching file"() {
         given:
         def file = new File(rootDir, "file.txt")
+        file.createNewFile()
 
         when:
         startWatcher(file)

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/BasicFileEventFunctionsTest.groovy
@@ -415,18 +415,15 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
     def "fails when watching non-existent directory"() {
         given:
         def missingDirectory = new File(rootDir, "missing")
-        def message = Platform.current().linux
-            ? "Couldn't stat path"
-            : "Couldn't add watch"
 
         when:
         startWatcher(missingDirectory)
 
         then:
         def ex = thrown NativeException
-        ex.message ==~ /${message}.*: ${Pattern.quote(missingDirectory.absolutePath)}/
+        ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}/
 
-        expectLogMessage(SEVERE, Pattern.compile("Caught exception: ${message}.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
+        expectLogMessage(SEVERE, Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(missingDirectory.absolutePath)}"))
     }
 
     // Apparently on macOS we can watch files
@@ -436,18 +433,15 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         given:
         def file = new File(rootDir, "file.txt")
         assert file.createNewFile()
-        def message = Platform.current().linux
-            ? "Couldn't add watch"
-            : "Couldn't start watching"
 
         when:
         startWatcher(file)
 
         then:
         def ex = thrown NativeException
-        ex.message ==~ /${message}.*: ${Pattern.quote(file.absolutePath)}/
+        ex.message ==~ /Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}/
 
-        expectLogMessage(SEVERE, Pattern.compile("Caught exception: ${message}.*: ${Pattern.quote(file.absolutePath)}"))
+        expectLogMessage(SEVERE, Pattern.compile("Caught exception: Couldn't add watch.*: ${Pattern.quote(file.absolutePath)}"))
     }
 
     def "fails when watching directory twice"() {

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
@@ -130,7 +130,7 @@ class MovedDirectoriesFileEventFunctionsTest extends AbstractFileEventFunctionsT
         Files.move(parentDir.toPath(), renamedDir.toPath())
 
         when:
-        def droppedPaths = watcher.stopWatchingMovedPaths()
+        def droppedPaths = watcher.stopWatchingMovedPaths([watchedDir])
         then:
         droppedPaths == [watchedDir]
 
@@ -142,7 +142,7 @@ class MovedDirectoriesFileEventFunctionsTest extends AbstractFileEventFunctionsT
         expectNoEvents()
 
         when:
-        droppedPaths = watcher.stopWatchingMovedPaths()
+        droppedPaths = watcher.stopWatchingMovedPaths([watchedDir])
         then:
         droppedPaths == []
     }

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package net.rubygrapefruit.platform.file
+
+import net.rubygrapefruit.platform.NativeException
+import net.rubygrapefruit.platform.internal.Platform
+import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions
+import net.rubygrapefruit.platform.internal.jni.NativeLogger
+import org.junit.Assume
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Unroll
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.logging.Level
+import java.util.logging.Logger
+import java.util.regex.Pattern
+
+import static java.util.concurrent.TimeUnit.SECONDS
+import static java.util.logging.Level.INFO
+import static java.util.logging.Level.SEVERE
+import static java.util.logging.Level.WARNING
+import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.OTHERWISE
+import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.WINDOWS
+import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.CREATED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.INVALIDATED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.MODIFIED
+import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.REMOVED
+
+@Unroll
+@Requires({ Platform.current().macOs || Platform.current().linux || Platform.current().windows })
+class MovedDirectoriesFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
+
+    def "can detect #ancestry removed"() {
+        given:
+        def parentDir = new File(rootDir, "parent")
+        def watchedDir = new File(parentDir, "removed")
+        watchedDir.mkdirs()
+        def removedFile = new File(watchedDir, "file.txt")
+        createNewFile(removedFile)
+        File removedDir = removedDirectory(watchedDir)
+        startWatcher(watchedDir)
+
+        when:
+        def directoryRemoved = removedDir.deleteDir()
+        // On Windows we don't always manage to remove the watched directory, but it's unreliable
+        if (!Platform.current().windows) {
+            assert directoryRemoved
+        }
+
+        def expectedEvents = []
+        if (Platform.current().macOs) {
+            expectedEvents << change(INVALIDATED, watchedDir)
+            if (ancestry == "watched directory") {
+                expectedEvents << change(REMOVED, watchedDir)
+            }
+        } else if (Platform.current().linux) {
+            expectedEvents << change(REMOVED, removedFile) << change(REMOVED, watchedDir)
+        } else if (Platform.current().windows) {
+            expectedEvents << change(MODIFIED, removedFile) << optionalChange(REMOVED, removedFile) << change(REMOVED, watchedDir)
+        }
+
+        then:
+        expectEvents expectedEvents
+
+        where:
+        ancestry                            | removedDirectory
+        "watched directory"                 | { it }
+        "parent of watched directory"       | { it.parentFile }
+        "grand-parent of watched directory" | { it.parentFile.parentFile }
+    }
+
+    @Issue("https://github.com/gradle/native-platform/issues/193")
+    def "can rename watched directory"() {
+        given:
+        def watchedDirectory = new File(rootDir, "watched")
+        watchedDirectory.mkdirs()
+        startWatcher(watchedDirectory)
+
+        when:
+        watchedDirectory.renameTo(new File(rootDir, "newWatched"))
+        waitForChangeEventLatency()
+        then:
+        if (Platform.current().linux) {
+            expectLogMessage(WARNING, Pattern.compile("Unknown event 0x800 for ${Pattern.quote(watchedDirectory.absolutePath)}"))
+        }
+        noExceptionThrown()
+    }
+
+    @Requires({ Platform.current().windows })
+    def "stops watching when path is moved"() {
+        given:
+        def watchedDir = new File(rootDir, "watched")
+        assert watchedDir.mkdirs()
+        def createdFile = new File(watchedDir, "created.txt")
+        startWatcher(watchedDir)
+
+        def renamedDir = new File(rootDir, "renamed")
+        assert watchedDir.renameTo(renamedDir)
+
+        when:
+        def droppedPaths = watcher.stopWatchingMovedPaths()
+        then:
+        droppedPaths == [watchedDir]
+
+        when:
+        assert createdFile.createNewFile()
+        then:
+        expectNoEvents()
+
+        when:
+        droppedPaths = watcher.stopWatchingMovedPaths()
+        then:
+        droppedPaths == []
+    }
+
+    @Requires({ Platform.current().linux || Platform.current().windows })
+    def "stops watching when parent of path is moved"() {
+        given:
+        def parentDir = new File(rootDir, "parent")
+        def watchedDir = new File(parentDir, "watched")
+        assert watchedDir.mkdirs()
+        startWatcher(watchedDir)
+
+        def renamedDir = new File(rootDir, "renamed")
+        assert parentDir.renameTo(renamedDir)
+
+        when:
+        def droppedPaths = watcher.stopWatchingMovedPaths()
+        then:
+        droppedPaths == [watchedDir]
+
+        when:
+        def createdFile = new File(watchedDir, "created.txt")
+        assert watchedDir.mkdirs()
+        assert createdFile.createNewFile()
+        then:
+        expectNoEvents()
+
+        when:
+        droppedPaths = watcher.stopWatchingMovedPaths()
+        then:
+        droppedPaths == []
+    }
+}

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
@@ -15,29 +15,15 @@
  */
 package net.rubygrapefruit.platform.file
 
-import net.rubygrapefruit.platform.NativeException
 import net.rubygrapefruit.platform.internal.Platform
-import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions
-import net.rubygrapefruit.platform.internal.jni.NativeLogger
-import org.junit.Assume
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Requires
 import spock.lang.Unroll
 
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.TimeUnit
-import java.util.logging.Level
-import java.util.logging.Logger
+import java.nio.file.Files
 import java.util.regex.Pattern
 
-import static java.util.concurrent.TimeUnit.SECONDS
-import static java.util.logging.Level.INFO
-import static java.util.logging.Level.SEVERE
 import static java.util.logging.Level.WARNING
-import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.OTHERWISE
-import static net.rubygrapefruit.platform.file.AbstractFileEventFunctionsTest.PlatformType.WINDOWS
-import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.CREATED
 import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.INVALIDATED
 import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.MODIFIED
 import static net.rubygrapefruit.platform.file.FileWatchEvent.ChangeType.REMOVED
@@ -111,7 +97,7 @@ class MovedDirectoriesFileEventFunctionsTest extends AbstractFileEventFunctionsT
         startWatcher(watchedDir)
 
         def renamedDir = new File(rootDir, "renamed")
-        assert watchedDir.renameTo(renamedDir)
+        Files.move(watchedDir.toPath(), renamedDir.toPath())
 
         when:
         def droppedPaths = watcher.stopWatchingMovedPaths()
@@ -138,7 +124,7 @@ class MovedDirectoriesFileEventFunctionsTest extends AbstractFileEventFunctionsT
         startWatcher(watchedDir)
 
         def renamedDir = new File(rootDir, "renamed")
-        assert parentDir.renameTo(renamedDir)
+        Files.move(parentDir.toPath(), renamedDir.toPath())
 
         when:
         def droppedPaths = watcher.stopWatchingMovedPaths()

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/WindowsFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/WindowsFileEventFunctionsTest.groovy
@@ -67,32 +67,6 @@ class WindowsFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         unsubst("G:")
     }
 
-    def "drops moved locations"() {
-        given:
-        def watchedDir = new File(rootDir, "watched")
-        assert watchedDir.mkdirs()
-        def renamedDir = new File(rootDir, "renamed")
-        def createdFile = new File(renamedDir, "created.txt")
-        startWatcher(watchedDir)
-
-        watchedDir.renameTo(renamedDir)
-
-        when:
-        def droppedPaths = watcher.stopWatchingMovedPaths()
-        then:
-        droppedPaths == [watchedDir]
-
-        when:
-        createdFile.createNewFile()
-        then:
-        expectNoEvents()
-
-        when:
-        droppedPaths = watcher.stopWatchingMovedPaths()
-        then:
-        droppedPaths == []
-    }
-
     def "does not drop subst drive as moved"() {
         given:
         subst("G:", rootDir)


### PR DESCRIPTION
A variation on #299, which allows passing in a list of locations to check. This avoids checking all the watched paths, which may be quite expensive on Linux.