### PR TITLE
Report unwatched directories as moved on stopWatchingMovedPaths

### DIFF
--- a/file-events/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/generic_fsnotifier.cpp
@@ -2,10 +2,6 @@
 
 #include "generic_fsnotifier.h"
 
-JavaExceptionThrownException::JavaExceptionThrownException()
-    : runtime_error("Java exception thrown from native code") {
-}
-
 InsufficientResourcesFileWatcherException::InsufficientResourcesFileWatcherException(const string& message)
     : FileWatcherException(message) {
 }

--- a/file-events/src/file-events/cpp/jni_support.cpp
+++ b/file-events/src/file-events/cpp/jni_support.cpp
@@ -83,6 +83,13 @@ void JniSupport::rethrowJavaException(JNIEnv* env) {
     }
 }
 
+void JniSupport::throwNativeExceptionWhenJavaExceptionOccurred(JNIEnv* env) {
+    jthrowable exception = env->ExceptionOccurred();
+    if (exception != nullptr) {
+        throw JavaExceptionThrownException();
+    }
+}
+
 BaseJniConstants::BaseJniConstants(JavaVM* jvm)
     : JniSupport(jvm)
     , classClass(getThreadEnv(), "java/lang/Class") {

--- a/file-events/src/file-events/cpp/jni_support.cpp
+++ b/file-events/src/file-events/cpp/jni_support.cpp
@@ -16,6 +16,10 @@ JavaVM* getJavaVm(JNIEnv* env) {
     return jvm;
 }
 
+JavaExceptionThrownException::JavaExceptionThrownException()
+    : runtime_error("Java exception thrown from native code") {
+}
+
 JniSupport::JniSupport(JavaVM* jvm)
     : jvm(jvm) {
 }

--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -387,10 +387,10 @@ Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_isGlibc0(J
 }
 
 JNIEXPORT void JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_00024LinuxFileWatcher_stopWatchingMovedPaths0(JNIEnv* env, jobject, jobject javaServer, jobjectArray absolutePathsToCheck, jobject jDroppedPaths) {
+Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_00024LinuxFileWatcher_stopWatchingMovedPaths0(JNIEnv* env, jobject, jobject javaServer, jobjectArray jAbsolutePathsToCheck, jobject jDroppedPaths) {
     try {
         Server* server = (Server*) getServer(env, javaServer);
-        server->stopWatchingMovedPaths(absolutePathsToCheck, jDroppedPaths);
+        server->stopWatchingMovedPaths(jAbsolutePathsToCheck, jDroppedPaths);
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
     }

--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -362,6 +362,7 @@ void Server::stopWatchingMovedPaths(jobjectArray absolutePathsToCheck, jobject d
 
 void Server::addToList(JNIEnv* env, jobject jList, jstring jString) {
         env->CallBooleanMethod(jList, listAddMethod, jString);
+        throwNativeExceptionWhenJavaExceptionOccurred(env);
 }
 
 JNIEXPORT jobject JNICALL
@@ -391,6 +392,8 @@ Java_net_rubygrapefruit_platform_internal_jni_LinuxFileEventFunctions_00024Linux
     try {
         Server* server = (Server*) getServer(env, javaServer);
         server->stopWatchingMovedPaths(jAbsolutePathsToCheck, jDroppedPaths);
+    } catch (const JavaExceptionThrownException&) {
+        // Ignore, the Java exception has already been thrown.
     } catch (const exception& e) {
         rethrowAsJavaException(env, e);
     }

--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -362,7 +362,6 @@ void Server::stopWatchingMovedPaths(jobjectArray absolutePathsToCheck, jobject d
 
 void Server::addToList(JNIEnv* env, jobject jList, jstring jString) {
         env->CallBooleanMethod(jList, listAddMethod, jString);
-        getJavaExceptionAndPrintStacktrace(env);
 }
 
 JNIEXPORT jobject JNICALL

--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -340,21 +340,25 @@ void Server::stopWatchingMovedPaths(jobjectArray absolutePathsToCheck, jobject d
         auto it = watchPoints.find(pathToCheck);
         if (it == watchPoints.end()) {
             addToList(env, droppedPaths, jPathToCheck);
+            env->DeleteLocalRef(jPathToCheck);
             continue;
         }
         auto& watchPoint = it->second;
         if (watchPoint.status != WatchPointStatus::LISTENING) {
             addToList(env, droppedPaths, jPathToCheck);
+            env->DeleteLocalRef(jPathToCheck);
             continue;
         }
 
         string pathNarrow = utf16ToUtf8String(watchPoint.path);
         struct stat st;
         if (lstat(pathNarrow.c_str(), &st) == 0 && st.st_ino == watchPoint.inode) {
+            env->DeleteLocalRef(jPathToCheck);
             continue;
         }
 
         addToList(env, droppedPaths, jPathToCheck);
+        env->DeleteLocalRef(jPathToCheck);
 
         watchPoint.cancel();
     }

--- a/file-events/src/file-events/cpp/linux_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/linux_fsnotifier.cpp
@@ -339,10 +339,12 @@ void Server::stopWatchingMovedPaths(jobjectArray absolutePathsToCheck, jobject d
 
         auto it = watchPoints.find(pathToCheck);
         if (it == watchPoints.end()) {
+            addToList(env, droppedPaths, jPathToCheck);
             continue;
         }
         auto& watchPoint = it->second;
         if (watchPoint.status != WatchPointStatus::LISTENING) {
+            addToList(env, droppedPaths, jPathToCheck);
             continue;
         }
 
@@ -352,11 +354,15 @@ void Server::stopWatchingMovedPaths(jobjectArray absolutePathsToCheck, jobject d
             continue;
         }
 
-        env->CallBooleanMethod(droppedPaths, listAddMethod, jPathToCheck);
-        getJavaExceptionAndPrintStacktrace(env);
+        addToList(env, droppedPaths, jPathToCheck);
 
         watchPoint.cancel();
     }
+}
+
+void Server::addToList(JNIEnv* env, jobject jList, jstring jString) {
+        env->CallBooleanMethod(jList, listAddMethod, jString);
+        getJavaExceptionAndPrintStacktrace(env);
 }
 
 JNIEXPORT jobject JNICALL

--- a/file-events/src/file-events/headers/generic_fsnotifier.h
+++ b/file-events/src/file-events/headers/generic_fsnotifier.h
@@ -29,14 +29,6 @@ enum class ChangeType {
 
 #define IS_SET(flags, mask) (((flags) & (mask)) != 0)
 
-// Throwing a Java exception from native code does not change the program flow.
-// So it may be necessary to throw a native exception as well which then can be catched in the outmost level just before returning to Java.
-// The idea here is that the catch clause for this exception is always empty.
-struct JavaExceptionThrownException : public runtime_error {
-public:
-    JavaExceptionThrownException();
-};
-
 struct InsufficientResourcesFileWatcherException : public FileWatcherException {
 public:
     InsufficientResourcesFileWatcherException(const string& message);

--- a/file-events/src/file-events/headers/jni_support.h
+++ b/file-events/src/file-events/headers/jni_support.h
@@ -49,6 +49,11 @@ public:
      */
     static void rethrowJavaException(JNIEnv* env);
 
+    /**
+     * Check for a Java exception and throw native JavaExceptionThrownException.
+     */
+    static void throwNativeExceptionWhenJavaExceptionOccurred(JNIEnv* env);
+
 protected:
     const JniGlobalRef<jclass>& findClass(const char* className);
     JNIEnv* getThreadEnv();

--- a/file-events/src/file-events/headers/jni_support.h
+++ b/file-events/src/file-events/headers/jni_support.h
@@ -23,6 +23,14 @@ struct deletable_facet : Facet {
 template <typename T>
 class JniGlobalRef;
 
+// Throwing a Java exception from native code does not change the program flow.
+// So it may be necessary to throw a native exception as well which then can be catched in the outmost level just before returning to Java.
+// The idea here is that the catch clause for this exception is always empty.
+struct JavaExceptionThrownException : public runtime_error {
+public:
+    JavaExceptionThrownException();
+};
+
 /**
  * Support for using JNI in a multi-threaded environment.
  */

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -111,6 +111,8 @@ private:
     void registerPath(const u16string& path);
     bool unregisterPath(const u16string& path);
 
+    void addToList(JNIEnv* env, jobject jList, jstring jString);
+
     recursive_mutex mutationMutex;
     unordered_map<u16string, WatchPoint> watchPoints;
     unordered_map<int, u16string> watchRoots;

--- a/file-events/src/file-events/headers/linux_fsnotifier.h
+++ b/file-events/src/file-events/headers/linux_fsnotifier.h
@@ -92,8 +92,8 @@ class Server : public AbstractServer {
 public:
     Server(JNIEnv* env, jobject watcherCallback);
 
-    // List<String> droppedPaths
-    void stopWatchingMovedPaths(const vector<u16string>& absolutePathsToCheck, jobject droppedPaths);
+    // List<String> absolutePathsToCheck, List<String> droppedPaths
+    void stopWatchingMovedPaths(jobjectArray absolutePathsToCheck, jobject droppedPaths);
 
     virtual void registerPaths(const vector<u16string>& paths) override;
     virtual bool unregisterPaths(const vector<u16string>& paths) override;

--- a/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
+++ b/file-events/src/test/groovy/net/rubygrapefruit/platform/file/MovedDirectoriesFileEventFunctionsTest.groovy
@@ -144,7 +144,29 @@ class MovedDirectoriesFileEventFunctionsTest extends AbstractFileEventFunctionsT
         when:
         droppedPaths = watcher.stopWatchingMovedPaths([watchedDir])
         then:
-        droppedPaths == []
+        droppedPaths == [watchedDir]
+    }
+
+    @Requires({ Platform.current().linux })
+    def "reports non-watched directory as moved on Linux"() {
+        given:
+        def parentDir = new File(rootDir, "parent")
+        def watchedDir = new File(parentDir, "watched")
+        def unwatchedDir = new File(watchedDir, "unwatched-directory")
+        assert watchedDir.mkdirs()
+        assert unwatchedDir.mkdirs()
+        startWatcher(watchedDir)
+
+        when:
+        def droppedPaths = watcher.stopWatchingMovedPaths([unwatchedDir])
+        then:
+        droppedPaths == [unwatchedDir]
+
+        when:
+        def createdFile = new File(watchedDir, "created.txt")
+        assert createdFile.createNewFile()
+        then:
+        expectEvents change(CREATED, createdFile)
     }
 
     @Requires({ Platform.current().macOs })


### PR DESCRIPTION
If a directory isn't watched any more on Linux, it should be reported by `stopWatchingMovedPaths()`, so the client can drop he state it retains for the unwatched directory as well.