### PR TITLE
Completes the migration to Nokee plugins

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     implementation gradleApi()
-    implementation platform('dev.nokee:nokee-gradle-plugins:0.4.1229-202112011142.4a01703c')
+    implementation platform('dev.nokee:nokee-gradle-plugins:0.4.1509-202202081144.9cd514f1')
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.1'
     implementation 'com.google.guava:guava:28.2-jre'
     implementation 'org.gradle:test-retry-gradle-plugin:1.1.8'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -52,5 +52,9 @@ gradlePlugin {
             id = "gradlebuild.ncurses"
             implementationClass = "gradlebuild.NcursesPlugin"
         }
+        ncursesRuntime {
+            id = "gradlebuild.ncurses-runtime"
+            implementationClass = "gradlebuild.NcursesRuntimePlugin"
+        }
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.1'
     implementation 'com.google.guava:guava:28.2-jre'
     implementation 'org.gradle:test-retry-gradle-plugin:1.1.8'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 java {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     implementation gradleApi()
-    implementation platform('dev.nokee:nokee-gradle-plugins:0.4.1560-202202152015.2a7d9703')
+    implementation platform('dev.nokee:nokee-gradle-plugins:0.4.1561-202202152051.db45d178')
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.1'
     implementation 'com.google.guava:guava:28.2-jre'
     implementation 'org.gradle:test-retry-gradle-plugin:1.1.8'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -44,6 +44,10 @@ gradlePlugin {
             id = "gradlebuild.freebsd"
             implementationClass = "gradlebuild.FreeBsdPlugin"
         }
+        freebsdRuntime {
+            id = "gradlebuild.freebsd-runtime"
+            implementationClass = "gradlebuild.FreeBsdRuntimePlugin"
+        }
         ncurses {
             id = "gradlebuild.ncurses"
             implementationClass = "gradlebuild.NcursesPlugin"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     implementation gradleApi()
-    implementation platform('dev.nokee:nokee-gradle-plugins:0.4.1509-202202081144.9cd514f1')
+    implementation platform('dev.nokee:nokee-gradle-plugins:0.4.1560-202202152015.2a7d9703')
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.1'
     implementation 'com.google.guava:guava:28.2-jre'
     implementation 'org.gradle:test-retry-gradle-plugin:1.1.8'

--- a/buildSrc/src/main/java/gradlebuild/BuildableExtension.java
+++ b/buildSrc/src/main/java/gradlebuild/BuildableExtension.java
@@ -1,0 +1,45 @@
+package gradlebuild;
+
+import dev.nokee.platform.jni.JniLibrary;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.Provider;
+
+import java.util.Set;
+
+import static gradlebuild.NcursesVersion.NCURSES_5;
+import static gradlebuild.NcursesVersion.NCURSES_6;
+
+public final class BuildableExtension {
+    private final Project project;
+    private final JniLibrary variant;
+
+    BuildableExtension(Project project, JniLibrary variant) {
+        this.project = project;
+        this.variant = variant;
+    }
+
+    public boolean isBuildable() {
+        if (!variant.getSharedLibrary().isBuildable()) {
+            return false; // strait-up not buildable
+        } else {
+            @SuppressWarnings("unchecked")
+            final Provider<Set<NcursesVersion>> availableNcursesVersions = (Provider<Set<NcursesVersion>>) project.getExtensions().findByName("availableNcursesVersions");
+            if (availableNcursesVersions == null) {
+                return true; // no known ncurses versions, assuming buildable
+            } else {
+                // For each variant with the ncurses dimension, check if the version is available
+                if (variant.getBuildVariant().hasAxisOf(NCURSES_5)) {
+                    return availableNcursesVersions.get().contains(NCURSES_5);
+                } else if (variant.getBuildVariant().hasAxisOf(NCURSES_6)) {
+                    return availableNcursesVersions.get().contains(NCURSES_6);
+                }
+                return true;
+            }
+        }
+    }
+
+    public static boolean isBuildable(JniLibrary variant) {
+        return ((ExtensionAware) variant).getExtensions().getByType(BuildableExtension.class).isBuildable();
+    }
+}

--- a/buildSrc/src/main/java/gradlebuild/FreeBsdRuntimePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/FreeBsdRuntimePlugin.java
@@ -1,0 +1,41 @@
+package gradlebuild;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.model.Mutate;
+import org.gradle.model.RuleSource;
+import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.toolchain.Clang;
+import org.gradle.nativeplatform.toolchain.NativeToolChainRegistry;
+
+import static gradlebuild.JavaNativeInterfaceLibraryUtils.library;
+
+public class FreeBsdRuntimePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(FreeBsdToolChainRules.class);
+
+        // We depend on custom JNI plugin because we are appending a new target machine
+        //   The custom JNI plugin overwrite the target machines
+        project.getPluginManager().withPlugin("gradlebuild.jni-nokee", ignored -> {
+            library(project, library -> {
+                library.getTargetMachines().add(library.getMachines().getFreeBSD().architecture("amd64"));
+            });
+        });
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static class FreeBsdToolChainRules extends RuleSource {
+        @Mutate void configureToolChains(NativeToolChainRegistry toolChainRegistry) {
+            toolChainRegistry.named("clang", Clang.class, toolChain ->
+                toolChain.eachPlatform(platformToolChain -> {
+                    NativePlatform platform = platformToolChain.getPlatform();
+                    if (platform.getOperatingSystem().isFreeBSD()) {
+                        platformToolChain.getcCompiler().setExecutable("cc");
+                        platformToolChain.getCppCompiler().setExecutable("c++");
+                        platformToolChain.getLinker().setExecutable("c++");
+                    }
+                }));
+        }
+    }
+}

--- a/buildSrc/src/main/java/gradlebuild/FreeBsdRuntimePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/FreeBsdRuntimePlugin.java
@@ -1,14 +1,15 @@
 package gradlebuild;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
-import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.toolchain.Clang;
 import org.gradle.nativeplatform.toolchain.NativeToolChainRegistry;
 
 import static gradlebuild.JavaNativeInterfaceLibraryUtils.library;
+import static gradlebuild.NativeRulesUtils.disableToolChain;
 
 public class FreeBsdRuntimePlugin implements Plugin<Project> {
     @Override
@@ -26,14 +27,16 @@ public class FreeBsdRuntimePlugin implements Plugin<Project> {
 
     @SuppressWarnings("UnstableApiUsage")
     public static class FreeBsdToolChainRules extends RuleSource {
-        @Mutate void configureToolChains(NativeToolChainRegistry toolChainRegistry) {
+        @Mutate
+        void configureToolChains(NativeToolChainRegistry toolChainRegistry) {
             toolChainRegistry.named("clang", Clang.class, toolChain ->
-                toolChain.eachPlatform(platformToolChain -> {
-                    NativePlatform platform = platformToolChain.getPlatform();
-                    if (platform.getOperatingSystem().isFreeBSD()) {
+                toolChain.target("freebsdx86-64", platformToolChain -> {
+                    if (SystemUtils.IS_OS_FREE_BSD) {
                         platformToolChain.getcCompiler().setExecutable("cc");
                         platformToolChain.getCppCompiler().setExecutable("c++");
                         platformToolChain.getLinker().setExecutable("c++");
+                    } else {
+                        disableToolChain(platformToolChain);
                     }
                 }));
         }

--- a/buildSrc/src/main/java/gradlebuild/JavaNativeInterfaceLibraryProperties.java
+++ b/buildSrc/src/main/java/gradlebuild/JavaNativeInterfaceLibraryProperties.java
@@ -1,0 +1,17 @@
+package gradlebuild;
+
+import dev.nokee.platform.jni.JavaNativeInterfaceLibrary;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.plugins.ExtensionAware;
+
+public final class JavaNativeInterfaceLibraryProperties {
+    private JavaNativeInterfaceLibraryProperties() {}
+
+    public static ConfigurableFileCollection cppSources(JavaNativeInterfaceLibrary library) {
+        return (ConfigurableFileCollection) ((ExtensionAware) library).getExtensions().getByName("cppSources");
+    }
+
+    public static ConfigurableFileCollection privateHeaders(JavaNativeInterfaceLibrary library) {
+        return (ConfigurableFileCollection) ((ExtensionAware) library).getExtensions().getByName("privateHeaders");
+    }
+}

--- a/buildSrc/src/main/java/gradlebuild/JavaNativeInterfaceLibraryUtils.java
+++ b/buildSrc/src/main/java/gradlebuild/JavaNativeInterfaceLibraryUtils.java
@@ -5,6 +5,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.Provider;
 
 final class JavaNativeInterfaceLibraryUtils {
     private JavaNativeInterfaceLibraryUtils() {}
@@ -19,5 +20,9 @@ final class JavaNativeInterfaceLibraryUtils {
 
     public static void library(Project project, Action<? super JavaNativeInterfaceLibrary> action) {
         project.getExtensions().configure("library", action);
+    }
+
+    public static Provider<JavaNativeInterfaceLibrary> library(Project project) {
+        return project.provider(() -> (JavaNativeInterfaceLibrary) project.getExtensions().getByName("library"));
     }
 }

--- a/buildSrc/src/main/java/gradlebuild/JavaNativeInterfaceLibraryUtils.java
+++ b/buildSrc/src/main/java/gradlebuild/JavaNativeInterfaceLibraryUtils.java
@@ -1,11 +1,13 @@
 package gradlebuild;
 
 import dev.nokee.platform.jni.JavaNativeInterfaceLibrary;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.plugins.ExtensionAware;
 
-public final class JavaNativeInterfaceLibraryProperties {
-    private JavaNativeInterfaceLibraryProperties() {}
+final class JavaNativeInterfaceLibraryUtils {
+    private JavaNativeInterfaceLibraryUtils() {}
 
     public static ConfigurableFileCollection cppSources(JavaNativeInterfaceLibrary library) {
         return (ConfigurableFileCollection) ((ExtensionAware) library).getExtensions().getByName("cppSources");
@@ -13,5 +15,9 @@ public final class JavaNativeInterfaceLibraryProperties {
 
     public static ConfigurableFileCollection privateHeaders(JavaNativeInterfaceLibrary library) {
         return (ConfigurableFileCollection) ((ExtensionAware) library).getExtensions().getByName("privateHeaders");
+    }
+
+    public static void library(Project project, Action<? super JavaNativeInterfaceLibrary> action) {
+        project.getExtensions().configure("library", action);
     }
 }

--- a/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
@@ -13,6 +13,7 @@ import dev.nokee.runtime.nativebase.TargetMachineFactory;
 import gradlebuild.actions.MixInJavaNativeInterfaceLibraryProperties;
 import gradlebuild.actions.RegisterJniTestTask;
 import groovy.util.Node;
+import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Namer;
@@ -56,6 +57,7 @@ import java.util.Set;
 import static com.google.common.collect.Streams.stream;
 import static gradlebuild.BuildableExtension.isBuildable;
 import static gradlebuild.JavaNativeInterfaceLibraryUtils.library;
+import static gradlebuild.NativeRulesUtils.disableToolChain;
 import static gradlebuild.NcursesVersion.NCURSES_5;
 import static gradlebuild.NcursesVersion.NCURSES_6;
 import static gradlebuild.WindowsDistribution.WINDOWS_XP_OR_LOWER;
@@ -397,7 +399,11 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
             });
             toolChainRegistry.create("clang", Clang.class, toolChain -> {
                 // The core Gradle toolchain for Clang only targets x86 and x86_64 out of the box.
-                toolChain.target("macosaarch64");
+                toolChain.target("macosaarch64", platformToolChain -> {
+                    if (!SystemUtils.IS_OS_MAC_OSX || !SystemUtils.OS_ARCH.equals("aarch64")) {
+                        disableToolChain(platformToolChain);
+                    }
+                });
             });
             toolChainRegistry.create("visualCpp", VisualCpp.class);
         }

--- a/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
@@ -32,9 +32,7 @@ import org.gradle.nativeplatform.toolchain.VisualCpp;
 import java.io.File;
 import java.util.Set;
 
-import static gradlebuild.JavaNativeInterfaceLibraryUtils.cppSources;
 import static gradlebuild.JavaNativeInterfaceLibraryUtils.library;
-import static gradlebuild.JavaNativeInterfaceLibraryUtils.privateHeaders;
 
 @SuppressWarnings("UnstableApiUsage")
 public abstract class JniNokeePlugin implements Plugin<Project> {
@@ -49,7 +47,6 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
         configureCppTasks(project);
         configureMainLibrary(project);
         configureVariants(project);
-        addComponentSourcesSetsToProjectSourceSet(project.getTasks(), project.getExtensions().getByType(JavaNativeInterfaceLibrary.class));
 
         configureNativeVersionGeneration(project);
         configureJniTest(project);
@@ -132,12 +129,6 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
         ((ExtensionAware) library).getExtensions().add("targetWindowsDistributions", newDimension);
     }
 
-    private void addComponentSourcesSetsToProjectSourceSet(TaskContainer tasks, JavaNativeInterfaceLibrary library) {
-        tasks.withType(WriteNativeVersionSources.class, task -> {
-            task.getNativeSources().from(cppSources(library), privateHeaders(library));
-        });
-    }
-
     private void configureCppTasks(Project project) {
         project.getPluginManager().withPlugin("dev.nokee.cpp-language", new MixInJavaNativeInterfaceLibraryProperties(project));
     }
@@ -163,6 +154,10 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
             task.getGeneratedJavaSourcesDir().set(new File(generatedFilesDir, "version/java"));
             task.getVersionClassPackageName().set(nativeVersion.getVersionClassPackageName());
             task.getVersionClassName().set(nativeVersion.getVersionClassName());
+            task.getNativeSources().from(
+                library(project).map(JavaNativeInterfaceLibraryUtils::cppSources),
+                library(project).map(JavaNativeInterfaceLibraryUtils::privateHeaders)
+            );
         });
 
 

--- a/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
@@ -145,6 +145,9 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
                     project.getGroup().toString().replace('.', '/'),
                     "platform",
                     VariantNamer.INSTANCE.determineName(variant)));
+                variant.getJavaNativeInterfaceJar().getJarTask().configure(task -> {
+                    task.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir("libs/main"));
+                });
             });
         });
     }

--- a/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
@@ -6,6 +6,7 @@ import dev.nokee.platform.jni.JavaNativeInterfaceLibrary;
 import dev.nokee.runtime.nativebase.TargetMachine;
 import dev.nokee.runtime.nativebase.TargetMachineFactory;
 import gradlebuild.actions.MixInJavaNativeInterfaceLibraryProperties;
+import gradlebuild.actions.RegisterJniTestTask;
 import groovy.util.Node;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -50,8 +51,13 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
         addComponentSourcesSetsToProjectSourceSet(project.getTasks(), project.getExtensions().getByType(JavaNativeInterfaceLibrary.class));
 
         configureNativeVersionGeneration(project);
+        configureJniTest(project);
 
         configurePomOfMainJar(project, variants);
+    }
+
+    private void configureJniTest(Project project) {
+        new RegisterJniTestTask().execute(project);
     }
 
     private void configureVariants(Project project) {

--- a/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniNokeePlugin.java
@@ -12,7 +12,6 @@ import dev.nokee.runtime.nativebase.TargetMachineFactory;
 import gradlebuild.actions.MixInJavaNativeInterfaceLibraryProperties;
 import gradlebuild.actions.RegisterJniTestTask;
 import groovy.util.Node;
-import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Namer;
@@ -53,7 +52,6 @@ import java.util.Set;
 
 import static com.google.common.collect.Streams.stream;
 import static gradlebuild.JavaNativeInterfaceLibraryUtils.library;
-import static gradlebuild.NativeRulesUtils.disableToolChain;
 import static gradlebuild.NcursesVersion.NCURSES_5;
 import static gradlebuild.NcursesVersion.NCURSES_6;
 import static gradlebuild.WindowsDistribution.WINDOWS_XP_OR_LOWER;
@@ -406,11 +404,7 @@ public abstract class JniNokeePlugin implements Plugin<Project> {
             });
             toolChainRegistry.create("clang", Clang.class, toolChain -> {
                 // The core Gradle toolchain for Clang only targets x86 and x86_64 out of the box.
-                toolChain.target("macosaarch64", platformToolChain -> {
-                    if (!SystemUtils.IS_OS_MAC_OSX || !SystemUtils.OS_ARCH.equals("aarch64")) {
-                        disableToolChain(platformToolChain);
-                    }
-                });
+                toolChain.target("macosaarch64");
             });
             toolChainRegistry.create("visualCpp", VisualCpp.class);
         }

--- a/buildSrc/src/main/java/gradlebuild/NativeRulesUtils.java
+++ b/buildSrc/src/main/java/gradlebuild/NativeRulesUtils.java
@@ -1,6 +1,7 @@
 package gradlebuild;
 
 import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.toolchain.GccPlatformToolChain;
 import org.gradle.platform.base.PlatformContainer;
 
 public interface NativeRulesUtils {
@@ -11,4 +12,14 @@ public interface NativeRulesUtils {
         });
     }
 
+    static void disableToolChain(GccPlatformToolChain platformToolChain) {
+        // Use a dummy so that Clang/GCC is not selected
+        platformToolChain.getcCompiler().setExecutable("dummy");
+        platformToolChain.getCppCompiler().setExecutable("dummy");
+        platformToolChain.getObjcCompiler().setExecutable("dummy");
+        platformToolChain.getObjcppCompiler().setExecutable("dummy");
+        platformToolChain.getAssembler().setExecutable("dummy");
+        platformToolChain.getLinker().setExecutable("dummy");
+        platformToolChain.getStaticLibArchiver().setExecutable("dummy");
+    }
 }

--- a/buildSrc/src/main/java/gradlebuild/NcursesRuntimePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/NcursesRuntimePlugin.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import dev.nokee.platform.base.BuildVariant;
 import dev.nokee.platform.base.Variant;
 import dev.nokee.platform.jni.JavaNativeInterfaceLibrary;
+import dev.nokee.runtime.nativebase.OperatingSystemFamily;
 import dev.nokee.runtime.nativebase.TargetMachineFactory;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -67,14 +68,9 @@ public class NcursesRuntimePlugin implements Plugin<Project> {
     }
 
     private SetProperty<NcursesVersion> registerNcursesDimension(JavaNativeInterfaceLibrary library) {
-        return library.getDimensions().newAxis(NcursesVersion.class, it -> it.filter(t -> {
-            if (t.hasAxisOf(library.getMachines().getWindows().getOperatingSystemFamily())) {
-                return t.hasAxisOf(NCURSES_5) || t.hasAxisOf(NCURSES_6);
-            } else if (t.hasAxisOf(library.getMachines().getLinux().getOperatingSystemFamily())) {
-                return false;
-            } else {
-                return t.hasAxisOf(NCURSES_6);
-            }
+        return library.getDimensions().newAxis(NcursesVersion.class, it -> it.onlyIf(OperatingSystemFamily.class, (ncurses, osFamily) -> {
+            return !ncurses.isPresent() || osFamily.isLinux()
+                || (!osFamily.isWindows() && ncurses.get().equals(NCURSES_5));
         }));
     }
 

--- a/buildSrc/src/main/java/gradlebuild/NcursesRuntimePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/NcursesRuntimePlugin.java
@@ -1,0 +1,109 @@
+package gradlebuild;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import dev.nokee.platform.base.BuildVariant;
+import dev.nokee.platform.base.Variant;
+import dev.nokee.platform.jni.JavaNativeInterfaceLibrary;
+import dev.nokee.runtime.nativebase.TargetMachineFactory;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.specs.Spec;
+import org.gradle.nativeplatform.platform.OperatingSystem;
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform;
+
+import java.io.File;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import static gradlebuild.JavaNativeInterfaceLibraryUtils.library;
+import static gradlebuild.NcursesVersion.NCURSES_5;
+import static gradlebuild.NcursesVersion.NCURSES_6;
+import static java.util.Arrays.stream;
+
+@SuppressWarnings("UnstableApiUsage")
+public class NcursesRuntimePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().add(new TypeOf<Provider<Set<NcursesVersion>>>() {}, "availableNcursesVersions", availableNcursesVersions(project));
+
+        project.getPluginManager().withPlugin("dev.nokee.jni-library", appliedPlugin -> {
+            library(project, library -> {
+                // Register ncurses dimension
+                SetProperty<NcursesVersion> ncurses = registerNcursesDimension(library);
+
+                // Defaults to all ncurses versions
+                ncurses.convention(ImmutableSet.copyOf(NcursesVersion.values()));
+
+                // Register dimension as library extensions
+                ((ExtensionAware) library).getExtensions().add("targetNcurses", ncurses);
+
+                library.getVariants().configureEach(ncursesVariant(), variant -> {
+                    variant.getSharedLibrary().getLinkTask().configure(task -> {
+                        task.getLinkerArgs().addAll(project.provider(ofNcursesLibraryFlags(library.getMachines(), variant.getBuildVariant())));
+                    });
+                });
+            });
+        });
+    }
+
+    private static Spec<Variant> ncursesVariant() {
+        return variant -> stream(NcursesVersion.values())
+            .anyMatch(it -> variant.getBuildVariant().hasAxisOf(it));
+    }
+
+    private static Callable<Iterable<String>> ofNcursesLibraryFlags(TargetMachineFactory machines, BuildVariant buildVariant) {
+        return () -> {
+            if (buildVariant.hasAxisOf(machines.getLinux().getOperatingSystemFamily()) && !buildVariant.hasAxisOf(NCURSES_5)) {
+                return ImmutableList.of("-lncursesw");
+            } else {
+                return ImmutableList.of("-lcurses");
+            }
+        };
+    }
+
+    private SetProperty<NcursesVersion> registerNcursesDimension(JavaNativeInterfaceLibrary library) {
+        return library.getDimensions().newAxis(NcursesVersion.class, it -> it.filter(t -> {
+            if (t.hasAxisOf(library.getMachines().getWindows().getOperatingSystemFamily())) {
+                return t.hasAxisOf(NCURSES_5) || t.hasAxisOf(NCURSES_6);
+            } else if (t.hasAxisOf(library.getMachines().getLinux().getOperatingSystemFamily())) {
+                return false;
+            } else {
+                return t.hasAxisOf(NCURSES_6);
+            }
+        }));
+    }
+
+    private Provider<Set<NcursesVersion>> availableNcursesVersions(Project project) {
+        final SetProperty<NcursesVersion> availableNcursesVersions = project.getObjects().setProperty(NcursesVersion.class);
+        availableNcursesVersions.value(project.provider(() -> {
+            final OperatingSystem os = new DefaultNativePlatform("current").getOperatingSystem();
+            final ImmutableSet.Builder<NcursesVersion> builder = ImmutableSet.builder();
+            if (!os.isLinux()) {
+                builder.add(NCURSES_5);
+            } else {
+                for (String d : ImmutableList.of("/lib", "/lib64", "/lib/x86_64-linux-gnu", "/lib/aarch64-linux-gnu", "/usr/lib")) {
+                    File libDir = new File(d);
+                    if (new File(libDir, "libncurses.so.6").isFile() || new File(libDir, "libncursesw.so.6").isFile()) {
+                        builder.add(NCURSES_6);
+                    }
+                    if (new File(libDir, "libncurses.so.5").isFile()) {
+                        builder.add(NCURSES_5);
+                    }
+                }
+            }
+            final ImmutableSet<NcursesVersion> versions = builder.build();
+            if (versions.isEmpty()) {
+                throw new IllegalArgumentException("Could not determine ncurses version installed on this machine.");
+            }
+            return versions;
+        }));
+        availableNcursesVersions.finalizeValueOnRead();
+        availableNcursesVersions.disallowChanges();
+        return availableNcursesVersions;
+    }
+}

--- a/buildSrc/src/main/java/gradlebuild/actions/MixInJavaNativeInterfaceLibraryProperties.java
+++ b/buildSrc/src/main/java/gradlebuild/actions/MixInJavaNativeInterfaceLibraryProperties.java
@@ -1,0 +1,45 @@
+package gradlebuild.actions;
+
+import dev.nokee.language.cpp.CppSourceSet;
+import dev.nokee.language.nativebase.internal.HasConfigurableHeaders;
+import dev.nokee.platform.jni.JavaNativeInterfaceLibrary;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.plugins.AppliedPlugin;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+/**
+ * This action bring the future to the present.
+ * In future release of Nokee, language plugins will mix-in their own {@literal ConfigurableFileCollection} properties on the component.
+ * For cpp-language, the properties {@literal cppSources} and {@literal privateHeaders} will be mixed in representing the component's sources as well as the conventional source layout.
+ * The action is an accurate approximation of what will be done automatically by Nokee's plugins.
+ */
+public final class MixInJavaNativeInterfaceLibraryProperties implements Action<AppliedPlugin> {
+    private final Project project;
+
+    public MixInJavaNativeInterfaceLibraryProperties(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void execute(AppliedPlugin ignored) {
+        JavaNativeInterfaceLibrary library = project.getExtensions().getByType(JavaNativeInterfaceLibrary.class);
+        final ConfigurableFileCollection cppSources = project.getObjects().fileCollection().from("src/main/cpp");
+        final ConfigurableFileCollection privateHeaders = project.getObjects().fileCollection().from("src/main/headers");
+
+        ((ExtensionAware) library).getExtensions().add(ConfigurableFileCollection.class, "cppSources", cppSources);
+        ((ExtensionAware) library).getExtensions().add(ConfigurableFileCollection.class, "privateHeaders", privateHeaders);
+
+        library.getSources().configureEach(CppSourceSet.class, sourceSet -> {
+            sourceSet.from(cppSources);
+            ((HasConfigurableHeaders) sourceSet).getHeaders().from(privateHeaders);
+
+            // We rewire the generated JNI headers here
+            //   because the convention gets overwritten on the first {@literal from} call.
+            //   The convention idea is something that will be phased out in the near future.
+            ((HasConfigurableHeaders) sourceSet).getHeaders().from(project.getTasks().named("compileJava", JavaCompile.class).flatMap(it -> it.getOptions().getHeaderOutputDirectory()));
+        });
+    }
+}

--- a/buildSrc/src/main/java/gradlebuild/actions/RegisterJniTestTask.java
+++ b/buildSrc/src/main/java/gradlebuild/actions/RegisterJniTestTask.java
@@ -1,0 +1,78 @@
+package gradlebuild.actions;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.StandardOutputListener;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.TestDescriptor;
+import org.gradle.api.tasks.testing.TestListener;
+import org.gradle.api.tasks.testing.TestResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RegisterJniTestTask implements Action<Project> {
+    @Override
+    public void execute(Project project) {
+        TaskProvider<Test> testJni = project.getTasks().register("testJni", Test.class, task -> {
+            // See https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/clopts002.html
+            task.jvmArgs("-Xcheck:jni");
+
+            // Only run tests that have the category
+            task.useJUnit(jUnitOptions ->
+                jUnitOptions.includeCategories("net.rubygrapefruit.platform.testfixture.JniChecksEnabled")
+            );
+            // Check standard output for JNI warnings and fail if we find anything
+            DetectJniWarnings detectJniWarnings = new DetectJniWarnings();
+            task.addTestListener(detectJniWarnings);
+            task.getLogging().addStandardOutputListener(detectJniWarnings);
+            task.doLast(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    List<String> detectedWarnings = detectJniWarnings.getDetectedWarnings();
+                    if (!detectedWarnings.isEmpty()) {
+                        throw new RuntimeException(String.format(
+                            "Detected JNI check warnings on standard output while executing tests:\n - %s",
+                            String.join("\n - ", detectedWarnings)
+                        ));
+                    }
+                }
+            });
+        });
+        project.getTasks().named("check", check -> check.dependsOn(testJni));
+    }
+
+    private static class DetectJniWarnings implements TestListener, StandardOutputListener {
+        private String currentTest;
+        private List<String> detectedWarnings = new ArrayList<>();
+
+        @Override
+        public void beforeSuite(TestDescriptor testDescriptor) {}
+
+        @Override
+        public void afterSuite(TestDescriptor testDescriptor, TestResult testResult) {}
+
+        @Override
+        public void beforeTest(TestDescriptor testDescriptor) {
+            currentTest = testDescriptor.getClassName() + "." + testDescriptor.getDisplayName();
+        }
+
+        @Override
+        public void afterTest(TestDescriptor testDescriptor, TestResult testResult) {
+            currentTest = null;
+        }
+
+        @Override
+        public void onOutput(CharSequence message) {
+            if (currentTest != null && message.toString().startsWith("WARNING")) {
+                detectedWarnings.add(String.format("%s (test: %s)", message, currentTest));
+            }
+        }
+
+        public List<String> getDetectedWarnings() {
+            return detectedWarnings;
+        }
+    }
+}

--- a/buildSrc/src/main/java/gradlebuild/actions/RegisterJniTestTask.java
+++ b/buildSrc/src/main/java/gradlebuild/actions/RegisterJniTestTask.java
@@ -17,6 +17,8 @@ public final class RegisterJniTestTask implements Action<Project> {
     @Override
     public void execute(Project project) {
         TaskProvider<Test> testJni = project.getTasks().register("testJni", Test.class, task -> {
+            task.setGroup("verification");
+
             // See https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/clopts002.html
             task.jvmArgs("-Xcheck:jni");
 

--- a/file-events/build.gradle
+++ b/file-events/build.gradle
@@ -4,8 +4,6 @@ plugins {
     id 'gradlebuild.jni-nokee'
 }
 
-import dev.nokee.language.cpp.CppSourceSet
-
 nativeVersion {
     versionClassPackageName = "net.rubygrapefruit.platform.internal.jni"
     versionClassName = "FileEventsVersion"
@@ -23,10 +21,8 @@ javadoc {
 
 library {
     baseName = 'native-platform-file-events'
-    sources.configureEach(CppSourceSet) {
-        source.from('src/file-events/cpp')
-        headers.from('src/file-events/headers')
-    }
+    cppSources.setFrom('src/file-events/cpp')
+    privateHeaders.setFrom('src/file-events/headers')
     tasks.configureEach(CppCompile) {
         compilerArgs.addAll(targetPlatform.map {
             if (it.operatingSystem.macOsX

--- a/file-events/build.gradle
+++ b/file-events/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'groovy'
     id 'dev.nokee.cpp-language'
     id 'gradlebuild.jni-nokee'
+    id 'gradlebuild.freebsd-runtime'
 }
 
 nativeVersion {

--- a/native-platform/build.gradle
+++ b/native-platform/build.gradle
@@ -7,7 +7,6 @@ plugins {
 //    id 'gradlebuild.ncurses'
 }
 
-import dev.nokee.language.cpp.CppSourceSet
 import gradlebuild.NcursesVersion
 
 nativeVersion {
@@ -25,10 +24,8 @@ javadoc {
 
 library {
     baseName = 'native-platform'
-    sources.configureEach(CppSourceSet) {
-        source.from('src/shared/cpp', 'src/main/cpp')
-        headers.from('src/shared/headers')
-    }
+    cppSources.setFrom('src/shared/cpp', 'src/main/cpp')
+    privateHeaders.setFrom('src/shared/headers')
     variants.configureEach {
         if (NcursesVersion.values().any { buildVariant.hasAxisOf(it) }) {
             baseName = 'native-platform-curses'

--- a/native-platform/build.gradle
+++ b/native-platform/build.gradle
@@ -29,6 +29,9 @@ library {
     variants.configureEach {
         if (NcursesVersion.values().any { buildVariant.hasAxisOf(it) }) {
             baseName = 'native-platform-curses'
+            sources.configureEach(dev.nokee.language.cpp.CppSourceSet) {
+                source.from('src/curses/cpp')
+            }
         }
     }
 }

--- a/native-platform/build.gradle
+++ b/native-platform/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'dev.nokee.cpp-language'
     id 'gradlebuild.jni-nokee'
     id 'gradlebuild.freebsd-runtime'
-//    id 'gradlebuild.ncurses'
+    id 'gradlebuild.ncurses-runtime'
 }
 
 import gradlebuild.NcursesVersion

--- a/native-platform/build.gradle
+++ b/native-platform/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-test-fixtures'
     id 'dev.nokee.cpp-language'
     id 'gradlebuild.jni-nokee'
-//    id 'gradlebuild.freebsd'
+    id 'gradlebuild.freebsd-runtime'
 //    id 'gradlebuild.ncurses'
 }
 


### PR DESCRIPTION
This PR relies on a locally published Nokee distribution with two minor fixes: 1) predicate filter for build variant and 2) ignores dimension with empty names when computing names. The final solution for those fixes will soon be integrated into master.

This PR focus on migrating the support for FreeBSD, Ncurses, publications and testJni task. All build features haven't been tested yet which is the next step in the migration.