### PR TITLE
Test file events on xfs and btrfs

### DIFF
--- a/.teamcity/NativePlatformBuild.kt
+++ b/.teamcity/NativePlatformBuild.kt
@@ -33,7 +33,7 @@ open class NativePlatformBuild(agent: Agent, buildReceiptSource: Boolean = false
 
     steps {
         gradle {
-            tasks = "clean build${agent.allPublishTasks} -PagentName=${agent.name}"
+            tasks = "clean build -PagentName=${agent.name}${agent.extraTestTasks}${agent.allPublishTasks}"
             if (buildReceiptSource) {
                 gradleParams = "-PignoreIncomingBuildReceipt"
             }

--- a/.teamcity/extensions.kt
+++ b/.teamcity/extensions.kt
@@ -97,6 +97,12 @@ val Agent.allPublishTasks
         else -> publishJniTasks
     }
 
+val Agent.extraTestTasks
+    get() = when (this) {
+        Agent.UbuntuAmd64 -> " :file-events:testBtrfs :file-Events:testXfs"
+        else -> ""
+    }
+
 fun BuildFeatures.lowerRequiredFreeDiskSpace() {
     freeDiskSpace {
         // Configure less than the default 3GB, since the disk of the agents is only 5GB big.

--- a/.teamcity/extensions.kt
+++ b/.teamcity/extensions.kt
@@ -99,7 +99,7 @@ val Agent.allPublishTasks
 
 val Agent.extraTestTasks
     get() = when (this) {
-        Agent.UbuntuAmd64 -> " :file-events:testBtrfs :file-Events:testXfs"
+        Agent.UbuntuAmd64 -> " :file-events:testBtrfs :file-events:testXfs"
         else -> ""
     }
 

--- a/buildSrc/src/main/java/gradlebuild/NativePlatformComponentPlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/NativePlatformComponentPlugin.java
@@ -1,9 +1,12 @@
 package gradlebuild;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.BasePlugin;
@@ -15,10 +18,14 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.process.ExecOperations;
 import org.gradle.testretry.TestRetryPlugin;
 import org.gradle.testretry.TestRetryTaskExtension;
 
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 public abstract class NativePlatformComponentPlugin implements Plugin<Project> {
@@ -72,11 +79,32 @@ public abstract class NativePlatformComponentPlugin implements Plugin<Project> {
             test.systemProperty("agentName", agentName.getOrElse("Unknown"));
         });
 
-        Stream.of("xfs", "btrfs").forEach(fileSystem -> {
-            project.getTasks().register("test" + capitalize(fileSystem), Test.class, test -> {
-                test.systemProperty(TEST_DIRECTORY_SYSTEM_PROPERTY, new File("/" + fileSystem, "native-platform/test files").getAbsolutePath());
-            });
-        });
+        Stream.of("xfs", "btrfs").forEach(fileSystemType ->
+            project.getTasks().register("test" + capitalize(fileSystemType), Test.class, test -> {
+                File mountPoint = new File("/" + fileSystemType);
+                test.systemProperty(TEST_DIRECTORY_SYSTEM_PROPERTY, new File(mountPoint, "native-platform/test files").getAbsolutePath());
+                test.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        Preconditions.checkArgument(mountPoint.isDirectory(),
+                            "Mount point for special file system %s is not a directory", mountPoint);
+                        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                        String findmntPath = Stream.of("/bin/findmnt", "/usr/bin/findmnt")
+                            .filter(path -> new File(path).isFile())
+                            .findAny()
+                            .orElseThrow(() -> new IllegalArgumentException("findmnt not found, make sure it is installed"));
+                        getExecOperations().exec(spec -> {
+                            spec.commandLine(
+                                findmntPath,
+                                "-n",  "-o", "FSTYPE", "-T", mountPoint);
+                            spec.setStandardOutput(outputStream);
+                        }).assertNormalExitValue();
+                        String detectedFileSystemType = new String(outputStream.toByteArray(), StandardCharsets.UTF_8).trim();
+                        Preconditions.checkArgument(fileSystemType.equals(detectedFileSystemType),
+                            "File system mounted at %s is not %s but %s", mountPoint, fileSystemType, detectedFileSystemType);
+                    }
+                });
+            }));
 
         // We need to add the root project to testImplementation manually, since we changed the wiring
         // for the test task to not use sourceSets.main.output.
@@ -85,6 +113,9 @@ public abstract class NativePlatformComponentPlugin implements Plugin<Project> {
         project.getDependencies().add("testImplementation", project.getDependencies().project(ImmutableMap.of("path", project.getPath())));
         dependencies.add("testImplementation", "org.spockframework:spock-core:1.3-groovy-2.5");
     }
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
 
     private static String capitalize(String name) {
         StringBuilder builder = new StringBuilder(name);

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
@@ -17,9 +17,13 @@
 package net.rubygrapefruit.platform.file
 
 import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.internal.Platform
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Requires
 import spock.lang.Specification
+
+import static org.junit.Assume.assumeTrue
 
 class FileSystemsTest extends Specification {
     private static final List<String> EXPECTED_FILE_SYSTEM_TYPES = [
@@ -53,5 +57,21 @@ class FileSystemsTest extends Specification {
         mountedFileSystems.collect() { it.mountPoint }.containsAll(File.listRoots())
         mountedFileSystems.every { it.caseSensitivity != null }
         mountedFileSystems.any { EXPECTED_FILE_SYSTEM_TYPES.contains(it.fileSystemType) }
+    }
+
+
+    @Requires({ Platform.current().linux })
+    def "mounts are set-up correctly"() {
+        def mountPoint = "/${fileSystemType}"
+        assumeTrue("Mount point for ${fileSystemType} exists", new File(mountPoint).exists())
+
+        when:
+        def mountedFileSystems = fileSystems.fileSystems
+        def specialFileSystem = mountedFileSystems.find { it.mountPoint.absolutePath == mountPoint }
+        then:
+        specialFileSystem.fileSystemType == fileSystemType
+
+        where:
+        fileSystemType << ["xfs", "btrfs"]
     }
 }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
@@ -61,7 +61,7 @@ class FileSystemsTest extends Specification {
 
 
     @Requires({ Platform.current().linux })
-    def "mounts are set-up correctly"() {
+    def "detects file systems of mount points correctly"() {
         def mountPoint = "/${fileSystemType}"
         assumeTrue("Mount point for ${fileSystemType} exists", new File(mountPoint).exists())
 


### PR DESCRIPTION
I added an xfs and a btrfs partition to the Ubuntu amd64 AMIs. We can now run the file event tests there as well to see that those two file systems are supported as well.