### PR TITLE
Report run loop termination errors before reporting the termination itself

### DIFF
--- a/file-events/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/generic_fsnotifier.cpp
@@ -14,7 +14,6 @@ AbstractServer::AbstractServer(JNIEnv* env, jobject watcherCallback)
     this->watcherReportUnknownEventMethod = env->GetMethodID(callbackClass, "reportUnknownEvent", "(Ljava/lang/String;)V");
     this->watcherReportOverflowMethod = env->GetMethodID(callbackClass, "reportOverflow", "(Ljava/lang/String;)V");
     this->watcherReportFailureMethod = env->GetMethodID(callbackClass, "reportFailure", "(Ljava/lang/Throwable;)V");
-    this->watcherReportTerminationMethod = env->GetMethodID(callbackClass, "reportTermination", "()V");
 }
 
 AbstractServer::~AbstractServer() {
@@ -53,11 +52,6 @@ void AbstractServer::reportFailure(JNIEnv* env, const exception& exception) {
     getJavaExceptionAndPrintStacktrace(env);
 }
 
-void AbstractServer::reportTermination(JNIEnv* env) {
-    env->CallVoidMethod(watcherCallback.get(), watcherReportTerminationMethod);
-    getJavaExceptionAndPrintStacktrace(env);
-}
-
 AbstractServer* getServer(JNIEnv* env, jobject javaServer) {
     AbstractServer* server = (AbstractServer*) env->GetDirectBufferAddress(javaServer);
     if (server == NULL) {
@@ -91,7 +85,6 @@ void AbstractServer::executeRunLoop(JNIEnv* env) {
     }
     unique_lock<mutex> terminationLock(terminationMutex);
     terminated = true;
-    reportTermination(env);
     terminationVariable.notify_all();
 }
 

--- a/file-events/src/file-events/headers/generic_fsnotifier.h
+++ b/file-events/src/file-events/headers/generic_fsnotifier.h
@@ -73,7 +73,6 @@ protected:
     void reportUnknownEvent(JNIEnv* env, const u16string& path);
     void reportOverflow(JNIEnv* env, const u16string& path);
     void reportFailure(JNIEnv* env, const exception& ex);
-    void reportTermination(JNIEnv* env);
 
 private:
     mutex terminationMutex;
@@ -85,7 +84,6 @@ private:
     jmethodID watcherReportUnknownEventMethod;
     jmethodID watcherReportOverflowMethod;
     jmethodID watcherReportFailureMethod;
-    jmethodID watcherReportTerminationMethod;
 };
 
 class NativePlatformJniConstants : public JniSupport {

--- a/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
+++ b/file-events/src/main/java/net/rubygrapefruit/platform/internal/jni/AbstractFileEventFunctions.java
@@ -176,6 +176,8 @@ public abstract class AbstractFileEventFunctions<W extends FileWatcher> implemen
                         }
                     } catch (Throwable e) {
                         callback.reportFailure(e);
+                    } finally {
+                        callback.reportTermination();
                     }
                 }
             };


### PR DESCRIPTION
Publish `TerminateEvent` after any errors related to stopping the native processor thread have been reported to the queue. This prevents the thread processing the event queue from exiting before seeing the `FailureEvent`.

Fixes https://github.com/gradle/native-platform/issues/319.