### PR TITLE
Add support for memory commit information on Windows

### DIFF
--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultWindowsMemory.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultWindowsMemory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal;
+
+import net.rubygrapefruit.platform.NativeException;
+import net.rubygrapefruit.platform.internal.jni.OsxMemoryFunctions;
+import net.rubygrapefruit.platform.internal.jni.WindowsMemoryFunctions;
+import net.rubygrapefruit.platform.memory.OsxMemory;
+import net.rubygrapefruit.platform.memory.OsxMemoryInfo;
+import net.rubygrapefruit.platform.memory.WindowsMemory;
+import net.rubygrapefruit.platform.memory.WindowsMemoryInfo;
+
+public class DefaultWindowsMemory implements WindowsMemory {
+    public WindowsMemoryInfo getMemoryInfo() throws NativeException {
+        FunctionResult result = new FunctionResult();
+        DefaultWindowsMemoryInfo memoryInfo = new DefaultWindowsMemoryInfo();
+        WindowsMemoryFunctions.getWindowsMemoryInfo(memoryInfo, result);
+        if (result.isFailed()) {
+            throw new NativeException(String.format("Could not get Windows memory info: %s", result.getMessage()));
+        }
+        return memoryInfo;
+    }
+}

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultWindowsMemoryInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/DefaultWindowsMemoryInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal;
+
+import net.rubygrapefruit.platform.memory.WindowsMemoryInfo;
+
+public class DefaultWindowsMemoryInfo implements WindowsMemoryInfo {
+    private long commitTotal;
+    private long commitLimit;
+    private long totalPhysicalMemory;
+    private long availablePhysicalMemory;
+
+    public void details(long commitTotal, long commitLimit, long totalPhysicalMemory, long availablePhysicalMemory) {
+        this.commitTotal = commitTotal;
+        this.commitLimit = commitLimit;
+        this.totalPhysicalMemory = totalPhysicalMemory;
+        this.availablePhysicalMemory = availablePhysicalMemory;
+    }
+
+    @Override
+    public long getCommitTotal() {
+        return commitTotal;
+    }
+
+    @Override
+    public long getCommitLimit() {
+        return commitLimit;
+    }
+
+    @Override
+    public long getTotalPhysicalMemory() {
+        return totalPhysicalMemory;
+    }
+
+    @Override
+    public long getAvailablePhysicalMemory() {
+        return availablePhysicalMemory;
+    }
+}

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -32,6 +32,7 @@ import net.rubygrapefruit.platform.internal.jni.PosixTypeFunctions;
 import net.rubygrapefruit.platform.internal.jni.TerminfoFunctions;
 import net.rubygrapefruit.platform.memory.Memory;
 import net.rubygrapefruit.platform.memory.OsxMemory;
+import net.rubygrapefruit.platform.memory.WindowsMemory;
 import net.rubygrapefruit.platform.terminal.Terminals;
 
 import java.util.Arrays;
@@ -180,6 +181,12 @@ public abstract class Platform {
             }
             if (type.equals(WindowsRegistry.class)) {
                 return type.cast(new DefaultWindowsRegistry());
+            }
+            if (type.equals(WindowsMemory.class)) {
+                return type.cast(new DefaultWindowsMemory());
+            }
+            if (type.equals(Memory.class)) {
+                return type.cast(new DefaultMemory());
             }
             return super.get(type, nativeLibraryLoader);
         }

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsMemoryFunctions.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsMemoryFunctions.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal.jni;
+
+import net.rubygrapefruit.platform.internal.DefaultOsxMemoryInfo;
+import net.rubygrapefruit.platform.internal.DefaultWindowsMemoryInfo;
+import net.rubygrapefruit.platform.internal.FunctionResult;
+
+public class WindowsMemoryFunctions {
+    public static native void getWindowsMemoryInfo(DefaultWindowsMemoryInfo memoryInfo, FunctionResult result);
+}

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/memory/WindowsMemory.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/memory/WindowsMemory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.memory;
+
+import net.rubygrapefruit.platform.NativeException;
+import net.rubygrapefruit.platform.NativeIntegration;
+import net.rubygrapefruit.platform.ThreadSafe;
+
+/**
+ * Provides Windows-specific details about the system memory.
+ */
+@ThreadSafe
+public interface WindowsMemory extends Memory, NativeIntegration {
+    /**
+     * Queries the current state of the system memory.
+     *
+     * @throws NativeException On failure.
+     */
+    @ThreadSafe
+    WindowsMemoryInfo getMemoryInfo() throws NativeException;
+}

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/memory/WindowsMemoryInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/memory/WindowsMemoryInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.memory;
+
+import net.rubygrapefruit.platform.ThreadSafe;
+
+/**
+ * Detailed Windows memory info.
+ *
+ * <p>
+ * See <a href="https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-performance_information">
+ * the Windows Process Status API</a> for detailed information on these values.
+ * </p>
+ *
+ * <p>
+ * Note that these integers are unsigned, so additional care must be taken to ensure that the values are interpreted
+ * correctly.
+ * </p>
+ */
+@ThreadSafe
+public interface WindowsMemoryInfo extends MemoryInfo {
+    long getCommitTotal();
+
+    long getCommitLimit();
+}

--- a/native-platform/src/shared/headers/win.h
+++ b/native-platform/src/shared/headers/win.h
@@ -23,6 +23,8 @@
 #include <Shlwapi.h>
 #include <wchar.h>
 #include <windows.h>
+#include <psapi.h>
+#include <intsafe.h>
 
 //
 // Converts a Java string to a UNICODE path, including the Long Path prefix ("\\?\")

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/MemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/MemoryTest.groovy
@@ -19,12 +19,21 @@ package net.rubygrapefruit.platform.memory
 import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Specification
 
 import java.lang.management.ManagementFactory
 
-@IgnoreIf({ !Platform.current().macOs })
+@Requires({ Platform.current().macOs || Platform.current().windows })
 class MemoryTest extends Specification {
+    static long getJmxTotalPhysicalMemory() {
+        ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
+    }
+
+    static long getJmxAvailablePhysicalMemory() {
+        ManagementFactory.operatingSystemMXBean.freePhysicalMemorySize
+    }
+
     def "caches memory instance"() {
         expect:
         def memory = Native.get(Memory.class)
@@ -40,9 +49,5 @@ class MemoryTest extends Specification {
         memoryInfo.totalPhysicalMemory == jmxTotalPhysicalMemory
         memoryInfo.availablePhysicalMemory > 0
         memoryInfo.availablePhysicalMemory <= memoryInfo.totalPhysicalMemory
-    }
-
-    long getJmxTotalPhysicalMemory() {
-        ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
     }
 }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/OsxMemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/OsxMemoryTest.groovy
@@ -24,7 +24,6 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
-import java.lang.management.ManagementFactory
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -53,8 +52,8 @@ class OsxMemoryTest extends Specification {
         memoryInfo.totalPhysicalMemory > 0
         memoryInfo.availablePhysicalMemory > 0
         memoryInfo.availablePhysicalMemory <= memoryInfo.totalPhysicalMemory
-        memoryInfo.totalPhysicalMemory == jmxTotalPhysicalMemory
-        memoryInfo.availablePhysicalMemory > jmxAvailablePhysicalMemory
+        memoryInfo.totalPhysicalMemory == MemoryTest.jmxTotalPhysicalMemory
+        memoryInfo.availablePhysicalMemory > MemoryTest.jmxAvailablePhysicalMemory
     }
 
     @Ignore
@@ -102,14 +101,6 @@ class OsxMemoryTest extends Specification {
         return csv
     }
 
-    long getJmxTotalPhysicalMemory() {
-        ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
-    }
-
-    long getJmxAvailablePhysicalMemory() {
-        ManagementFactory.operatingSystemMXBean.freePhysicalMemorySize
-    }
-
     def VMSTAT_LINE_PATTERN = Pattern.compile(/^\D+(\d+)\D+$/)
     def vmstatMatcher = VMSTAT_LINE_PATTERN.matcher("")
 
@@ -139,7 +130,7 @@ class OsxMemoryTest extends Specification {
                 freeCount += speculativeCount
             }
         }
-        long totalMem = jmxTotalPhysicalMemory
+        long totalMem = MemoryTest.jmxTotalPhysicalMemory
         long availableMem = (freeCount + externalCount) * pageSize
         DefaultOsxMemoryInfo info = new DefaultOsxMemoryInfo()
         info.details(pageSize,

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/WindowsMemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/WindowsMemoryTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.memory
+
+import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.internal.Platform
+import spock.lang.Requires
+import spock.lang.Specification
+
+@Requires({ Platform.current().windows })
+class WindowsMemoryTest extends Specification {
+
+    def "caches memory instance"() {
+        expect:
+        def memory = Native.get(WindowsMemory.class)
+        memory.is(Native.get(WindowsMemory.class))
+    }
+
+    def "can query Windows memory info"() {
+        given:
+        def memory = Native.get(WindowsMemory.class)
+
+        when:
+        def memoryInfo = memory.memoryInfo
+        def totalPhysicalMemory = MemoryTest.jmxTotalPhysicalMemory
+        def availablePhysicalMemory = MemoryTest.jmxAvailablePhysicalMemory
+
+        then:
+        memoryInfo.totalPhysicalMemory > 0
+        memoryInfo.availablePhysicalMemory > 0
+        memoryInfo.availablePhysicalMemory <= memoryInfo.totalPhysicalMemory
+        memoryInfo.commitTotal > 0
+        memoryInfo.commitLimit > memoryInfo.commitTotal
+        // Windows commitLimit must be greater than the physical memory, since it is that plus the page files
+        memoryInfo.commitLimit >= memoryInfo.totalPhysicalMemory
+        memoryInfo.totalPhysicalMemory == totalPhysicalMemory
+        // These measurements should be close to each other, possibly inequal due to system memory churn
+        Math.abs(memoryInfo.availablePhysicalMemory - availablePhysicalMemory) < 1024 * 1024
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,8 @@ See [Prompter](native-platform/src/main/java/net/rubygrapefruit/platform/prompts
 * Query kernel name and version.
 * Query machine architecture.
 * Query hostname.
-* Query total and available memory (OS X only).
+* Query total and available memory (OS X and Windows only).
+* Query system commit total and limit (Windows only).
 
 See [SystemInfo](native-platform/src/main/java/net/rubygrapefruit/platform/SystemInfo.java)
 
@@ -123,6 +124,7 @@ Some sample code to use the terminal:
 ### 0.22 (unreleased)
 
 * Remove support for 32bit Linux & FreeBSD, as well as support for FreeBSD < 10.
+* Implement `Memory` and add `WindowsMemory` for Windows.
 
 ### 0.21
 

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -39,6 +39,8 @@ import net.rubygrapefruit.platform.internal.jni.OsxFileEventFunctions;
 import net.rubygrapefruit.platform.internal.jni.WindowsFileEventFunctions;
 import net.rubygrapefruit.platform.memory.Memory;
 import net.rubygrapefruit.platform.memory.MemoryInfo;
+import net.rubygrapefruit.platform.memory.WindowsMemory;
+import net.rubygrapefruit.platform.memory.WindowsMemoryInfo;
 import net.rubygrapefruit.platform.prompts.Prompter;
 import net.rubygrapefruit.platform.terminal.TerminalInput;
 import net.rubygrapefruit.platform.terminal.TerminalInputListener;
@@ -355,6 +357,14 @@ public class Main {
             MemoryInfo memory = Native.get(Memory.class).getMemoryInfo();
             System.out.println("* Available memory: " + memory.getAvailablePhysicalMemory());
             System.out.println("* Total memory: " + memory.getTotalPhysicalMemory());
+        } catch (NativeIntegrationUnavailableException e) {
+            // ignore
+        }
+
+        try {
+            WindowsMemoryInfo memory = Native.get(WindowsMemory.class).getMemoryInfo();
+            System.out.println("* Windows Commit Limit: " + memory.getCommitLimit());
+            System.out.println("* Windows Commit Total: " + memory.getCommitTotal());
         } catch (NativeIntegrationUnavailableException e) {
             // ignore
         }


### PR DESCRIPTION
This uses the `GetPerformanceInfo` API to access the information.