### PR TITLE
Remove `pgpSigningKey` param in Kotlin DSL code

### DIFF
--- a/.teamcity/NativePlatformPublishing.kt
+++ b/.teamcity/NativePlatformPublishing.kt
@@ -61,8 +61,6 @@ open class NativePlatformPublishSnapshot(releaseType: ReleaseType, uploadTasks: 
     params {
         param("ARTIFACTORY_USERNAME", releaseType.username)
         password("ARTIFACTORY_PASSWORD", releaseType.password, display = ParameterDisplay.HIDDEN)
-        password("pgpSigningKey", "credentialsJSON:ae6de222-f77d-4c71-b94e-fac6da485143", display = ParameterDisplay.HIDDEN)
-        password("pgpSigningPassphrase", "credentialsJSON:f75db3bd-4f5b-4591-b5cb-2e76d91f57f5", display = ParameterDisplay.HIDDEN)
         if (releaseType.userProvidedVersion) {
             text("reverse.dep.*.$versionPostfixParameterName", "${releaseType.gradleProperty}-1", display = ParameterDisplay.PROMPT, allowEmpty = false)
         }


### PR DESCRIPTION
Let's move it to `Gradle Native` TeamCity project level (https://builds.gradle.org/admin/editProject.html?projectId=GradleNative&tab=projectParams), so we can update the param without touching the code.