### PR TITLE
Add flag to file-events build to build without outline atomics

### DIFF
--- a/file-events/build.gradle
+++ b/file-events/build.gradle
@@ -33,6 +33,7 @@ model {
                     cppCompiler.args "-pthread"                 // Force nicer threading
                     cppCompiler.args "-pedantic"                // Disable non-standard things
                     cppCompiler.args "--std=c++11"              // Enable C++11
+                    cppCompiler.args "-mno-outline-atomics"     // Disable __getauxval calls, fixes gradle/gradle#24875 on aarch64
                     cppCompiler.args "-Wall"                    // All warnings
                     cppCompiler.args "-Wextra"                  // Plus extra
                     cppCompiler.args "-Wformat=2"               // Check printf format strings


### PR DESCRIPTION
This should fix gradle/gradle#24875, as no __getauxval calls will be generated by gcc.
I couldn't find a way to test this, so I'd really appreciate if someone could build a nightly version for me to test.