### PR TITLE
Switch to using FSEventStreamSetDispatchQueue on macOS for file events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 *.ipr
 *.iws
+*.log
 
 **/.classpath
 **/.project

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -12,8 +12,8 @@
             "macFrameworkPath": [
                 "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks"
             ],
-            "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
             "intelliSenseMode": "clang-x64"
         },
         {

--- a/buildSrc/src/main/java/gradlebuild/JniPlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniPlugin.java
@@ -299,8 +299,8 @@ public abstract class JniPlugin implements Plugin<Project> {
             Tool linker = binarySpec.getLinker();
             if (targetOs.isMacOsX()) {
                 cppCompiler.getArgs().addAll(determineJniIncludes("darwin"));
-                cppCompiler.args("-mmacosx-version-min=10.9");
-                linker.args("-mmacosx-version-min=10.9");
+                cppCompiler.args("-mmacosx-version-min=10.13");
+                linker.args("-mmacosx-version-min=10.13");
                 linker.args("-framework", "CoreServices");
             } else if (targetOs.isLinux()) {
                 cppCompiler.getArgs().addAll(determineJniIncludes("linux"));

--- a/file-events/build.gradle
+++ b/file-events/build.gradle
@@ -27,12 +27,19 @@ model {
                 targetPlatform p.name
             }
             binaries.all {
+                if (targetPlatform.operatingSystem.macOsX) {
+                    cppCompiler.args "--std=c++17"              // Enable C++17
+                } else if (targetPlatform.operatingSystem.linux) {
+                    cppCompiler.args "-std=c++11"               // Enable C++11
+                } else if (targetPlatform.operatingSystem.windows) {
+                    cppCompiler.args "/std:c++17"               // Won't hurt
+                }
+
                 if (targetPlatform.operatingSystem.macOsX
                     || targetPlatform.operatingSystem.linux) {
                     cppCompiler.args "-g"                       // Produce debug output
                     cppCompiler.args "-pthread"                 // Force nicer threading
                     cppCompiler.args "-pedantic"                // Disable non-standard things
-                    cppCompiler.args "--std=c++11"              // Enable C++11
                     cppCompiler.args "-Wall"                    // All warnings
                     cppCompiler.args "-Wextra"                  // Plus extra
                     cppCompiler.args "-Wformat=2"               // Check printf format strings
@@ -42,7 +49,6 @@ model {
                     linker.args "-pthread"
                 } else if (targetPlatform.operatingSystem.windows) {
                     cppCompiler.args "/DEBUG"                   // Produce debug output
-                    cppCompiler.args "/std:c++17"               // Won't hurt
                     cppCompiler.args "/permissive-"             // Make compiler more standards compatible
                     cppCompiler.args "/EHsc"                    // Force exception handling mode
                     cppCompiler.args "/Zi"                      // Force PDB debugging

--- a/file-events/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/apple_fsnotifier.cpp
@@ -99,6 +99,9 @@ void Server::handleEvents(
     const FSEventStreamEventId eventIds[]) {
     try {
         for (size_t i = 0; i < numEvents; i++) {
+            // This code runs on an arbitrary thread, so we can't pass it back to Java from here,
+            // as the JNIEnv is not available on this thread. We pass it to the Java run loop thread
+            // using our own queue instead.
             eventQueue.enqueue(FileEvent {
                 eventPaths[i],
                 eventFlags[i],

--- a/file-events/src/file-events/cpp/apple_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/apple_fsnotifier.cpp
@@ -139,7 +139,7 @@ void Server::shutdownRunLoop() {
     watchPoints.clear();
     // This waits for the dispatch queue to empty completely; without it we might get events
     // after the server has been destroyed.
-    dispatch_async_and_wait_f(dispatchQueue, nullptr, doNothing);
+    dispatch_sync_f(dispatchQueue, nullptr, doNothing);
     eventQueue.enqueue(PoisonPill());
 }
 

--- a/file-events/src/file-events/cpp/generic_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/generic_fsnotifier.cpp
@@ -42,8 +42,12 @@ void AbstractServer::reportOverflow(JNIEnv* env, const u16string& path) {
 }
 
 void AbstractServer::reportFailure(JNIEnv* env, const exception& exception) {
-    u16string message = utf8ToUtf16String(exception.what());
-    jstring javaMessage = env->NewString((jchar*) message.c_str(), (jsize) message.length());
+    reportFailure(env, exception.what());
+}
+
+void AbstractServer::reportFailure(JNIEnv* env, const char* message) {
+    u16string utf16Message = utf8ToUtf16String(message);
+    jstring javaMessage = env->NewString((jchar*) utf16Message.c_str(), (jsize) utf16Message.length());
     jmethodID constructor = env->GetMethodID(nativePlatformJniConstants->nativeExceptionClass.get(), "<init>", "(Ljava/lang/String;)V");
     jobject javaException = env->NewObject(nativePlatformJniConstants->nativeExceptionClass.get(), constructor, javaMessage);
     env->CallVoidMethod(watcherCallback.get(), watcherReportFailureMethod, javaException);

--- a/file-events/src/file-events/cpp/jni_support.cpp
+++ b/file-events/src/file-events/cpp/jni_support.cpp
@@ -115,11 +115,16 @@ void javaToUtf16StringArray(JNIEnv* env, jobjectArray javaStrings, vector<u16str
     strings.reserve(count);
     for (int i = 0; i < count; i++) {
         jstring javaString = reinterpret_cast<jstring>(env->GetObjectArrayElement(javaStrings, i));
-        auto string = javaToUtf16String(env, javaString);
+        u16string string = javaToUtf16String(env, javaString);
         env->DeleteLocalRef(javaString);
-        strings.push_back(std::move(string));
+        strings.push_back(string);
     }
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 u16string utf8ToUtf16String(const char* string) {
     wstring_convert<deletable_facet<codecvt<char16_t, char, mbstate_t>>, char16_t> conv16;
@@ -130,3 +135,7 @@ string utf16ToUtf8String(const u16string& string) {
     wstring_convert<deletable_facet<codecvt<char16_t, char, mbstate_t>>, char16_t> conv16;
     return conv16.to_bytes(string);
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif

--- a/file-events/src/file-events/headers/apple_fsnotifier.h
+++ b/file-events/src/file-events/headers/apple_fsnotifier.h
@@ -24,10 +24,6 @@ private:
     std::queue<T> queue;
 
 public:
-    virtual ~BlockingQueue() {
-        fprintf(stderr, "Destroying queue\n");
-    }
-
     // Enqueue an item into the queue and notify one waiting thread
     void enqueue(const T& item) {
         {
@@ -69,7 +65,6 @@ public:
 
 private:
     FSEventStreamRef watcherStream;
-    u16string path;
 };
 
 struct FileEvent {

--- a/file-events/src/file-events/headers/generic_fsnotifier.h
+++ b/file-events/src/file-events/headers/generic_fsnotifier.h
@@ -72,6 +72,7 @@ protected:
     void reportChangeEvent(JNIEnv* env, ChangeType type, const u16string& path);
     void reportUnknownEvent(JNIEnv* env, const u16string& path);
     void reportOverflow(JNIEnv* env, const u16string& path);
+    void reportFailure(JNIEnv* env, const char* message);
     void reportFailure(JNIEnv* env, const exception& ex);
 
 private:

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ See [WindowsRegistry](native-platform/src/main/java/net/rubygrapefruit/platform/
 
 Currently ported to OS X, Linux, FreeBSD and Windows. Support for Solaris is a work in progress. Supported on:
 
-* OS X, version 10.9 and later (x86_64)
+* OS X, version 10.13 and later (x86_64)
 * Fedora 23 and later (amd64).
 * Ubuntu 8.04 and later (amd64).
 * Ubuntu 18.04 and later (aarch64).
@@ -337,7 +337,7 @@ Finally, add the linked `native-platform` project [as a participant to the Gradl
 
 # Releasing
 
-See [this issue](https://github.com/gradle/native-platform/issues/271) first. 
+See [this issue](https://github.com/gradle/native-platform/issues/271) first.
 
 In the meantime, this [TC job](https://builds.gradle.org/buildConfiguration/GradleNative_NativePlatform_Publishing_PublishJavaApiAlpha?branch=&buildTypeTab=overview&mode=builds) should be used to publish a milestone.
 [Add a tag](https://github.com/gradle/native-platform/tags) afterward.


### PR DESCRIPTION
The [FSEventStreamScheduleWithRunLoop](https://developer.apple.com/documentation/coreservices/1447824-fseventstreamschedulewithrunloop?language=objc) API we've been using has been deprecated since macOS 13. We need to switch to [FSEventStreamSetDispatchQueue](https://developer.apple.com/documentation/coreservices/1444164-fseventstreamsetdispatchqueue?language=objc).

Fixes #315.

This also bumps C++ from C++11 to C++17 on macOS to get access to `std::variant`.

That means we stop support for macOS 10.9 and require macOS 10.13.

According to https://endoflife.date/macos, macOS 10.12 Sierra (the latest we'll stop supporting) has received the last update (10.12.6) on 19 Jul 2017, more than 6.5 years ago, and has been in end-of-life since 1 Oct 2019, almost 4.5 years ago.

Even macOS 10.13 High Sierra (the oldest version we keep support for) has reached end-of-life on 1st Dec 2020, more than 3 years ago, and has received the last update 5.5 years ago.