### PR TITLE
Zig it

### DIFF
--- a/file-events/.gitignore
+++ b/file-events/.gitignore
@@ -1,0 +1,1 @@
+.zig-cache/

--- a/file-events/.gitignore
+++ b/file-events/.gitignore
@@ -1,1 +1,2 @@
 .zig-cache/
+zig-out/

--- a/file-events/build.zig
+++ b/file-events/build.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addSharedLibrary(.{ .name = "file-events", .target = target, .optimize = optimize });
+
+    const env = std.process.getEnvMap(b.allocator) catch unreachable;
+    const java_home = env.get("JAVA_HOME") orelse unreachable;
+    const java_include_path = std.fmt.allocPrint(b.allocator, "{s}/include", .{java_home}) catch unreachable;
+    const java_darwin_include_path = std.fmt.allocPrint(b.allocator, "{s}/include/darwin", .{java_home}) catch unreachable;
+
+    // Add include directories
+    lib.addIncludePath(b.path("build/generated/sources/headers/java/main"));
+    lib.addIncludePath(b.path("build/generated/version/header"));
+    lib.addIncludePath(b.path("src/file-events/headers"));
+    lib.addSystemIncludePath(.{ .cwd_relative = java_include_path });
+    lib.addSystemIncludePath(.{ .cwd_relative = java_darwin_include_path });
+
+    // Set common C++ compiler flags
+    const cpp_args = [_][]const u8{
+        "--std=c++17",
+        "-g",
+        "-pedantic",
+        "-Wall",
+        "-Wextra",
+        "-Wformat=2",
+        "-Werror",
+        "-Wno-deprecated-declarations",
+        "-Wno-format-nonliteral",
+        "-Wno-unguarded-availability-new",
+    };
+
+    // Add source files
+    lib.addCSourceFiles(.{
+        .files = &.{
+            "src/file-events/cpp/apple_fsnotifier.cpp",
+            "src/file-events/cpp/file-events-version.cpp",
+            "src/file-events/cpp/generic_fsnotifier.cpp",
+            "src/file-events/cpp/jni_support.cpp",
+            "src/file-events/cpp/linux_fsnotifier.cpp",
+            "src/file-events/cpp/logging.cpp",
+            "src/file-events/cpp/services.cpp",
+            "src/file-events/cpp/win_fsnotifier.cpp",
+        },
+        .flags = &cpp_args,
+    });
+
+    // Link against libc and libstdc++
+    lib.linkLibC();
+    lib.linkLibCpp();
+
+    // // Platform-specific configurations
+    // if (target.os.tag == .macos or target.os.tag == .linux) {
+    //     lib.c_flags.append("-pthread");
+
+    //     // Set linker flags
+    //     lib.linker_flags.append("-pthread");
+    // } else if (target.os.tag == .windows) {
+    //     lib.c_flags = &[_][]const u8{
+    //         "/DEBUG",
+    //         "/permissive-",
+    //         "/EShc",
+    //         "/Zi",
+    //         "/FS",
+    //         "/Zc:inline",
+    //         "/Zc:throwingNew",
+    //         "/W3",
+    //         "/WX",
+    //         "/D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING",
+    //     };
+
+    //     // Set linker flags
+    //     lib.linker_flags = &[_][]const u8{
+    //         "/DEBUG:FULL",
+    //     };
+    // }
+
+    // lib.verbose_cc = true;
+    // lib.verbose_link = true;
+
+    const install = b.addInstallArtifact(lib, .{});
+
+    // Ensure the library is built
+    const build_step = b.step("build", "Build the file-events shared library");
+    build_step.dependOn(&install.step);
+}

--- a/file-events/build.zig
+++ b/file-events/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
     lib.addSystemIncludePath(.{ .cwd_relative = java_include_path });
     lib.addSystemIncludePath(.{ .cwd_relative = java_darwin_include_path });
 
-    const cpp_args = &[_][]const u8{
+    const base_cpp_args = &[_][]const u8{
         "--std=c++17",
         "-g",
         "-pedantic",
@@ -29,9 +29,14 @@ pub fn build(b: *std.Build) void {
         "-Wno-deprecated-declarations",
         "-Wno-format-nonliteral",
         "-Wno-unguarded-availability-new",
-        // TODO Only pass this for Windows
-        "-DNTDDI_VERSION=NTDDI_WIN10_RS3",
     };
+
+    const cpp_args = if (target.result.os.tag == .windows)
+        base_cpp_args ++ &[_][]const u8{
+            "-DNTDDI_VERSION=NTDDI_WIN10_RS3",
+        }
+    else
+        base_cpp_args;
 
     // Add source files
     lib.addCSourceFiles(.{

--- a/file-events/build.zig
+++ b/file-events/build.zig
@@ -52,6 +52,11 @@ pub fn build(b: *std.Build) void {
     lib.linkLibC();
     lib.linkLibCpp();
 
+    if (target.result.os.tag == .macos) {
+        lib.linkFramework("CoreFoundation");
+        lib.linkFramework("CoreServices");
+    }
+
     // lib.verbose_cc = true;
     // lib.verbose_link = true;
 

--- a/file-events/build.zig
+++ b/file-events/build.zig
@@ -18,8 +18,7 @@ pub fn build(b: *std.Build) void {
     lib.addSystemIncludePath(.{ .cwd_relative = java_include_path });
     lib.addSystemIncludePath(.{ .cwd_relative = java_darwin_include_path });
 
-    // Set common C++ compiler flags
-    const cpp_args = [_][]const u8{
+    const cpp_args = &[_][]const u8{
         "--std=c++17",
         "-g",
         "-pedantic",
@@ -30,6 +29,8 @@ pub fn build(b: *std.Build) void {
         "-Wno-deprecated-declarations",
         "-Wno-format-nonliteral",
         "-Wno-unguarded-availability-new",
+        // TODO Only pass this for Windows
+        "-DNTDDI_VERSION=NTDDI_WIN10_RS3",
     };
 
     // Add source files
@@ -44,38 +45,12 @@ pub fn build(b: *std.Build) void {
             "src/file-events/cpp/services.cpp",
             "src/file-events/cpp/win_fsnotifier.cpp",
         },
-        .flags = &cpp_args,
+        .flags = cpp_args,
     });
 
     // Link against libc and libstdc++
     lib.linkLibC();
     lib.linkLibCpp();
-
-    // // Platform-specific configurations
-    // if (target.os.tag == .macos or target.os.tag == .linux) {
-    //     lib.c_flags.append("-pthread");
-
-    //     // Set linker flags
-    //     lib.linker_flags.append("-pthread");
-    // } else if (target.os.tag == .windows) {
-    //     lib.c_flags = &[_][]const u8{
-    //         "/DEBUG",
-    //         "/permissive-",
-    //         "/EShc",
-    //         "/Zi",
-    //         "/FS",
-    //         "/Zc:inline",
-    //         "/Zc:throwingNew",
-    //         "/W3",
-    //         "/WX",
-    //         "/D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING",
-    //     };
-
-    //     // Set linker flags
-    //     lib.linker_flags = &[_][]const u8{
-    //         "/DEBUG:FULL",
-    //     };
-    // }
 
     // lib.verbose_cc = true;
     // lib.verbose_link = true;

--- a/file-events/src/file-events/cpp/win_fsnotifier.cpp
+++ b/file-events/src/file-events/cpp/win_fsnotifier.cpp
@@ -91,13 +91,13 @@ bool resolveFinalPath(HANDLE handle, wstring& path) {
 //
 
 WatchPoint::WatchPoint(Server* server, size_t eventBufferSize, const wstring& path)
-    : registeredPath(path)
-    , status(WatchPointStatus::NOT_LISTENING)
-    , server(server) {
+    : server(server)
+    , registeredPath(path)
+    , status(WatchPointStatus::NOT_LISTENING) {
     wstring longPath = path;
     convertToLongPathIfNeeded(longPath);
     HANDLE directoryHandle = CreateFileW(
-        longPath.c_str(),           // pointer to the file name
+        longPath.c_str(),       // pointer to the file name
         FILE_LIST_DIRECTORY,    // access (read/write) mode
         CREATE_SHARE,           // share mode
         NULL,                   // security descriptor
@@ -477,7 +477,7 @@ void Server::stopWatchingMovedPaths(jobject droppedPaths) {
 //
 
 JNIEXPORT jobject JNICALL
-Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatcher0(JNIEnv* env, jclass target, jint eventBufferSize, jlong commandTimeoutInMillis, jobject javaCallback) {
+Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWatcher0(JNIEnv* env, jclass, jint eventBufferSize, jlong commandTimeoutInMillis, jobject javaCallback) {
     return wrapServer(env, new Server(env, eventBufferSize, (long) commandTimeoutInMillis, javaCallback));
 }
 

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -2,7 +2,6 @@
 
 #ifdef _WIN32
 
-#include <Shlwapi.h>
 #include <functional>
 #include <string>
 #include <unordered_map>

--- a/file-events/src/file-events/headers/win_fsnotifier.h
+++ b/file-events/src/file-events/headers/win_fsnotifier.h
@@ -75,6 +75,8 @@ public:
     ListenResult listen();
     bool cancel();
 
+    void handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred);
+
 private:
     bool isValidDirectory();
     void close();
@@ -120,9 +122,6 @@ private:
      * Whether the watch point is watching, has been cancelled or fully closed.
      */
     WatchPointStatus status;
-
-    void handleEventsInBuffer(DWORD errorCode, DWORD bytesTransferred);
-    friend static void CALLBACK handleEventCallback(DWORD errorCode, DWORD bytesTransferred, LPOVERLAPPED overlapped);
 };
 
 class Server : public AbstractServer {
@@ -156,7 +155,6 @@ private:
     const long commandTimeoutInMillis;
     unordered_map<wstring, WatchPoint> watchPoints;
     bool shouldTerminate = false;
-    friend void CALLBACK executeOnRunLoopCallback(_In_ ULONG_PTR info);
     jmethodID listAddMethod;
 };
 


### PR DESCRIPTION
Some experiments with cross-compilation using [Zig](https://ziglang.org)'s C/C++ cross-compilation support. My efforts are focused on getting `file-events` to cross-compile, though they should be relatively simple to extend to the rest of `native-platform`.

I used Zig 0.13, the currently released version. I installed it with `brew install zig`. The recommendation is to use the nightly, though, as Zig is moving fast; perhaps that would take us further in some ways.

## Attempt 1: rewire Gradle

At first I tried getting Gradle to use Zig's commands to build by adding this under `model {}`:

```groovy
model {
    toolChains {
        clang(Clang) {
            eachPlatform {
                cCompiler.executable = "zcc"
                cppCompiler.executable = "z++"
            }
        }
    }
    // ...
}
```

...and adding a couple bash scripts to invoke `zig cc` and `zig c++` for those names. This got me to compile the code for the local platform on macOS, and I could run the tests and all. 🎉

However, I couldn't get multi-platform working this way, as I could get Zig's linker to step in.

## Attempt 2: use Zig build

I then went with another direction, and tried to re-phrase the native part of the build in Zig.

### Cross-compiling on macOS to Linux

This worked all the way, and I can now cross-compile on macOS like this:

```console
$ uname -a
Darwin N2W52L96LD 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000 arm64
$ zig build build -Dtarget=x86_64-linux-gnu
$ file zig-out/lib/libfile-events.so 
zig-out/lib/libfile-events.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, with debug_info, not stripped
```

🎉

I haven't tried the library yet from Java, but I think it's highly likely that it would work.

Cross-compilation to `aarch64` works, too:

```console
$ zig build build -Dtarget=aarch64-linux-gnu  
$ file zig-out/lib/libfile-events.so 
zig-out/lib/libfile-events.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, with debug_info, not stripped
```

### Compiling locally on macOS

~Compilation works well, and I got object files. However, the linker fails because it can't find the `CoreFoundation` library. I'm not completely sure how to fix this.~

Compilation and linking works when not cross-compiling.

~It also looks like if we wanted to cross-compile macOS on Linux, we'd need something like https://github.com/tpoechtrager/osxcrossd.~

Notes on cross-compiling on Linux: https://github.com/ziglang/zig/issues/1349. We essentially need the macOS SDKs packaged up and available, as detailed in https://github.com/tpoechtrager/osxcross#packaging-the-sdk.

Another option is to do cross-compilation for all platforms on a Mac where the SDK is available.

### Cross-compiling to Windows

~This worked the worst. IIUC, MSVC C++ support is just not there yet in Zig (https://github.com/ziglang/zig/issues/5312). We could use the GNU toolchain, which would require some slight adjustments to the code. I did not try that yet.~

Got this working with the GNU toolchain with a few small modifications to the code:

```console
$ zig build build -Dtarget=x86_64-windows-gnu 
$ file zig-out/bin/file-events.dll 
zig-out/bin/file-events.dll: PE32+ executable (DLL) (GUI) x86-64, for MS Windows
```

I could also cross-compile to `aarch64`:

```console
$ zig build build -Dtarget=aarch64-windows-gnu 
$ file zig-out/bin/file-events.dll                   
zig-out/bin/file-events.dll: PE32+ executable (DLL) (GUI) Aarch64, for MS Windows
```

## Shrinking

This is as simple as passing `-Doptimize=ReleaseSmall` on the command-line. Each platform/arch builds to a ~500 kB library that compresses down to around 140 kB with `gzip` (the size we need to ship). This is somewhat larger for macOS where we currently ship ~80 kB gzip'd, but much smaller for Windows and Linux where we ship 3-400 kB for each platform/arch. Overall we'd save space, even after adding more platforms like Windows and Linux ARM.

## TODO

- [ ] Try Zig nightly
- [ ] Integrate Zig build into the Gradle build
- [ ] Use Zig also for `native-platform` (not just `file-events`)
- [ ] Make this work on CI (we can build on Zig's Docker image)
- [x] Shrink the size of the produced libraries (we can strip symbols etc.)
- [x] Figure out how to build for macOS
- [x] Get cross-arch compilation working
- [x] Rework Windows code to work with GNU toolchain
