### PR TITLE
Require explicit initialization of native integration

### DIFF
--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/NativePlatformSpec.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/NativePlatformSpec.groovy
@@ -1,0 +1,18 @@
+package net.rubygrapefruit.platform
+
+import spock.lang.Specification
+
+class NativePlatformSpec extends Specification {
+    static boolean nativeInitialized
+
+    def setupSpec() {
+        if (!nativeInitialized) {
+            def tempRoot = java.nio.file.Paths.get("build/test-outputs")
+            java.nio.file.Files.createDirectories(tempRoot)
+            def cacheDir = java.nio.file.Files.createTempDirectory(tempRoot, "native-platform").toFile()
+            cacheDir.mkdirs()
+            Native.init(cacheDir)
+            nativeInitialized = true
+        }
+    }
+}

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/NativePlatformSpec.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/NativePlatformSpec.groovy
@@ -3,16 +3,18 @@ package net.rubygrapefruit.platform
 import spock.lang.Specification
 
 class NativePlatformSpec extends Specification {
-    static boolean nativeInitialized
+    private static Native nativeIntegration
 
-    def setupSpec() {
-        if (!nativeInitialized) {
-            def tempRoot = java.nio.file.Paths.get("build/test-outputs")
-            java.nio.file.Files.createDirectories(tempRoot)
-            def cacheDir = java.nio.file.Files.createTempDirectory(tempRoot, "native-platform").toFile()
-            cacheDir.mkdirs()
-            Native.init(cacheDir)
-            nativeInitialized = true
+    static protected <T> T getIntegration(Class<T> type) {
+        synchronized (NativePlatformSpec) {
+            if (nativeIntegration == null) {
+                def tempRoot = java.nio.file.Paths.get("build/test-outputs")
+                java.nio.file.Files.createDirectories(tempRoot)
+                def cacheDir = java.nio.file.Files.createTempDirectory(tempRoot, "native-platform").toFile()
+                cacheDir.mkdirs()
+                nativeIntegration = Native.init(cacheDir)
+            }
         }
+        nativeIntegration.get(type)
     }
 }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessLauncherTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessLauncherTest.groovy
@@ -16,9 +16,7 @@
 
 package net.rubygrapefruit.platform
 
-import spock.lang.Specification
-
-class ProcessLauncherTest extends Specification {
+class ProcessLauncherTest extends NativePlatformSpec {
     final ProcessLauncher launcher = Native.get(ProcessLauncher)
 
     def "can start a child process"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessLauncherTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessLauncherTest.groovy
@@ -17,7 +17,7 @@
 package net.rubygrapefruit.platform
 
 class ProcessLauncherTest extends NativePlatformSpec {
-    final ProcessLauncher launcher = Native.get(ProcessLauncher)
+    final ProcessLauncher launcher = getIntegration(ProcessLauncher)
 
     def "can start a child process"() {
         def javaHome = System.getProperty("java.home")

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessTest.groovy
@@ -20,9 +20,8 @@ import net.rubygrapefruit.platform.testfixture.JavaVersion
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.IgnoreIf
-import spock.lang.Specification
 
-class ProcessTest extends Specification {
+class ProcessTest extends NativePlatformSpec {
     @Rule TemporaryFolder tmpDir
     final Process process = Native.get(Process.class)
 

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/ProcessTest.groovy
@@ -23,11 +23,11 @@ import spock.lang.IgnoreIf
 
 class ProcessTest extends NativePlatformSpec {
     @Rule TemporaryFolder tmpDir
-    final Process process = Native.get(Process.class)
+    final Process process = getIntegration(Process)
 
     def "caches process instance"() {
         expect:
-        Native.get(Process.class) == process
+        getIntegration(Process) == process
     }
 
     def "can get PID"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/SystemInfoTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/SystemInfoTest.groovy
@@ -16,12 +16,7 @@
 
 package net.rubygrapefruit.platform
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class SystemInfoTest extends Specification {
-    @Rule TemporaryFolder tmpDir
+class SystemInfoTest extends NativePlatformSpec {
     final SystemInfo systemInfo = Native.get(SystemInfo.class)
 
     def "caches system info instance"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/SystemInfoTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/SystemInfoTest.groovy
@@ -17,11 +17,11 @@
 package net.rubygrapefruit.platform
 
 class SystemInfoTest extends NativePlatformSpec {
-    final SystemInfo systemInfo = Native.get(SystemInfo.class)
+    final SystemInfo systemInfo = getIntegration(SystemInfo)
 
     def "caches system info instance"() {
         expect:
-        Native.get(SystemInfo.class) == systemInfo
+        getIntegration(SystemInfo) == systemInfo
     }
 
     def "can query OS details"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/WindowsRegistryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/WindowsRegistryTest.groovy
@@ -5,7 +5,7 @@ import spock.lang.IgnoreIf
 
 @IgnoreIf({!Platform.current().windows})
 class WindowsRegistryTest extends NativePlatformSpec {
-    def windowsRegistry = Native.get(WindowsRegistry)
+    def windowsRegistry = getIntegration(WindowsRegistry)
 
     def "can read string value"() {
         expect:

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/WindowsRegistryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/WindowsRegistryTest.groovy
@@ -2,10 +2,9 @@ package net.rubygrapefruit.platform
 
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.IgnoreIf
-import spock.lang.Specification
 
 @IgnoreIf({!Platform.current().windows})
-class WindowsRegistryTest extends Specification {
+class WindowsRegistryTest extends NativePlatformSpec {
     def windowsRegistry = Native.get(WindowsRegistry)
 
     def "can read string value"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
@@ -16,8 +16,8 @@
 
 package net.rubygrapefruit.platform.file
 
+import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
-import spock.lang.Specification
 
 import java.nio.file.LinkOption
 import java.nio.file.Paths
@@ -25,9 +25,17 @@ import java.nio.file.attribute.BasicFileAttributeView
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFileAttributes
 
-import static java.nio.file.attribute.PosixFilePermission.*
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
 
-class AbstractFilesTest extends Specification {
+class AbstractFilesTest extends NativePlatformSpec {
     BasicFileAttributes attributes(File file) {
         return java.nio.file.Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes()
     }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FileSystemsTest.groovy
@@ -16,16 +16,15 @@
 
 package net.rubygrapefruit.platform.file
 
-import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Requires
-import spock.lang.Specification
 
 import static org.junit.Assume.assumeTrue
 
-class FileSystemsTest extends Specification {
+class FileSystemsTest extends NativePlatformSpec {
     private static final List<String> EXPECTED_FILE_SYSTEM_TYPES = [
         // APFS on macOS
         'apfs',
@@ -43,11 +42,11 @@ class FileSystemsTest extends Specification {
 
     @Rule TemporaryFolder tmpDir
 
-    final FileSystems fileSystems = Native.get(FileSystems.class)
+    final FileSystems fileSystems = getIntegration(FileSystems)
 
     def "caches file systems instance"() {
         expect:
-        Native.get(FileSystems.class) == fileSystems
+        getIntegration(FileSystems) == fileSystems
     }
 
     def "can query filesystem details"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
@@ -15,7 +15,6 @@
  */
 package net.rubygrapefruit.platform.file
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.internal.Platform
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -36,7 +35,7 @@ abstract class FilesTest extends AbstractFilesTest {
     ])
     @Rule
     TemporaryFolder tmpDir
-    final def files = Native.get(Files.class)
+    final def files = getIntegration(Files.class)
 
     void assertIsFile(FileInfo stat, File file) {
         assert stat.type == FileInfo.Type.File
@@ -104,7 +103,7 @@ abstract class FilesTest extends AbstractFilesTest {
 
     def "caches file instance"() {
         expect:
-        Native.get(Files.class) == files
+        getIntegration(Files) == files
     }
 
     @Unroll
@@ -269,7 +268,7 @@ abstract class FilesTest extends AbstractFilesTest {
         stat.size == 0
 
         where:
-        fileSystem << Native.get(FileSystems.class).fileSystems
+        fileSystem << getIntegration(FileSystems).fileSystems
     }
 
     @Unroll

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/PosixFilesTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/PosixFilesTest.groovy
@@ -1,6 +1,5 @@
 package net.rubygrapefruit.platform.file
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativeException
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.IgnoreIf
@@ -11,11 +10,13 @@ import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFileAttributes
 import java.nio.file.attribute.PosixFilePermission
 
-import static java.nio.file.attribute.PosixFilePermission.*
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
 
 @IgnoreIf({ Platform.current().windows })
 class PosixFilesTest extends FilesTest {
-    final PosixFiles files = Native.get(PosixFiles.class)
+    final PosixFiles files = getIntegration(PosixFiles)
 
     @Override
     void assertIsFile(FileInfo stat, File file) {
@@ -58,8 +59,8 @@ class PosixFilesTest extends FilesTest {
 
     def "uses same instance for specialized file types"() {
         expect:
-        Native.get(PosixFiles.class) == files
-        Native.get(Files.class) == files
+        getIntegration(PosixFiles) == files
+        getIntegration(Files) == files
     }
 
     def "can stat a file with no read permissions"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/WindowsFilesTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/file/WindowsFilesTest.groovy
@@ -1,12 +1,11 @@
 package net.rubygrapefruit.platform.file
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ !Platform.current().windows })
 class WindowsFilesTest extends FilesTest {
-    final WindowsFiles files = Native.get(WindowsFiles.class)
+    final WindowsFiles files = getIntegration(WindowsFiles)
 
     @Override
     void assertIsFile(FileInfo stat, File file) {
@@ -28,8 +27,8 @@ class WindowsFilesTest extends FilesTest {
 
     def "uses same instance for specialized file types"() {
         expect:
-        Native.get(WindowsFiles.class) == files
-        Native.get(Files.class) == files
+        getIntegration(WindowsFiles) == files
+        getIntegration(Files) == files
     }
 
     def "can stat file using UNC path"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/internal/NativeTypeInfoTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/internal/NativeTypeInfoTest.groovy
@@ -17,11 +17,11 @@
 package net.rubygrapefruit.platform.internal
 
 import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.NativePlatformSpec
 import spock.lang.IgnoreIf
-import spock.lang.Specification
 
 @IgnoreIf({Platform.current().windows})
-class NativeTypeInfoTest extends Specification {
+class NativeTypeInfoTest extends NativePlatformSpec {
     def "can fetch native type info"() {
         expect:
         MutableTypeInfo typeInfo = Native.get(MutableTypeInfo.class)

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/internal/NativeTypeInfoTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/internal/NativeTypeInfoTest.groovy
@@ -16,7 +16,6 @@
 
 package net.rubygrapefruit.platform.internal
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativePlatformSpec
 import spock.lang.IgnoreIf
 
@@ -24,7 +23,7 @@ import spock.lang.IgnoreIf
 class NativeTypeInfoTest extends NativePlatformSpec {
     def "can fetch native type info"() {
         expect:
-        MutableTypeInfo typeInfo = Native.get(MutableTypeInfo.class)
+        def typeInfo = getIntegration(MutableTypeInfo)
         println "int: ${typeInfo.int_bytes}"
         println "u_long: ${typeInfo.u_long_bytes}"
         println "size_t: ${typeInfo.size_t_bytes}"

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/internal/PrompterTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/internal/PrompterTest.groovy
@@ -1,15 +1,14 @@
 package net.rubygrapefruit.platform.internal
 
 import net.rubygrapefruit.platform.NativeException
+import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.prompts.Prompter
 import net.rubygrapefruit.platform.terminal.TerminalInput
 import net.rubygrapefruit.platform.terminal.TerminalInputListener
 import net.rubygrapefruit.platform.terminal.Terminals
-import spock.lang.Specification
 import spock.lang.Unroll
 
-
-class PrompterTest extends Specification {
+class PrompterTest extends NativePlatformSpec {
     def terminals = Stub(Terminals)
 
     @Unroll

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/MemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/MemoryTest.groovy
@@ -16,7 +16,6 @@
 
 package net.rubygrapefruit.platform.memory
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Requires
@@ -35,13 +34,13 @@ class MemoryTest extends NativePlatformSpec {
 
     def "caches memory instance"() {
         expect:
-        def memory = Native.get(Memory.class)
-        memory.is(Native.get(Memory.class))
+        def memory = getIntegration(Memory)
+        memory.is(getIntegration(Memory))
     }
 
     def "can query system memory"() {
         expect:
-        def memory = Native.get(Memory.class)
+        def memory = getIntegration(Memory)
 
         def memoryInfo = memory.memoryInfo
         memoryInfo.totalPhysicalMemory > 0
@@ -53,12 +52,12 @@ class MemoryTest extends NativePlatformSpec {
     @Requires({ Platform.current().windows })
     def "memory instance is the OS-specific implementation on Windows"() {
         expect:
-        Native.get(Memory.class) instanceof WindowsMemory
+        getIntegration(Memory) instanceof WindowsMemory
     }
 
     @Requires({ Platform.current().macOs })
     def "memory instance is the OS-specific implementation on OSX"() {
         expect:
-        Native.get(Memory.class) instanceof OsxMemory
+        getIntegration(Memory) instanceof OsxMemory
     }
 }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/MemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/MemoryTest.groovy
@@ -17,15 +17,14 @@
 package net.rubygrapefruit.platform.memory
 
 import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
-import spock.lang.IgnoreIf
 import spock.lang.Requires
-import spock.lang.Specification
 
 import java.lang.management.ManagementFactory
 
 @Requires({ Platform.current().macOs || Platform.current().windows })
-class MemoryTest extends Specification {
+class MemoryTest extends NativePlatformSpec {
     static long getJmxTotalPhysicalMemory() {
         ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
     }

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/OsxMemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/OsxMemoryTest.groovy
@@ -16,7 +16,6 @@
 
 package net.rubygrapefruit.platform.memory
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.DefaultOsxMemoryInfo
 import net.rubygrapefruit.platform.internal.Platform
@@ -32,13 +31,13 @@ class OsxMemoryTest extends NativePlatformSpec {
 
     def "caches memory instance"() {
         expect:
-        def memory = Native.get(OsxMemory.class)
-        memory.is(Native.get(OsxMemory.class))
+        def memory = getIntegration(OsxMemory)
+        memory.is(getIntegration(OsxMemory))
     }
 
     def "can query OSX memory info"() {
         given:
-        def memory = Native.get(OsxMemory.class)
+        def memory = getIntegration(OsxMemory)
 
         when:
         def vmStatInfo = getFromVmStatCommand()
@@ -59,7 +58,7 @@ class OsxMemoryTest extends NativePlatformSpec {
     @Ignore
     def "indefinitely sample OSX memory info"() {
         given:
-        def memory = Native.get(OsxMemory.class)
+        def memory = getIntegration(OsxMemory)
         def conditions = new PollingConditions(timeout: Double.MAX_VALUE, initialDelay: 5, delay: 5)
 
         expect:

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/OsxMemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/OsxMemoryTest.groovy
@@ -17,18 +17,18 @@
 package net.rubygrapefruit.platform.memory
 
 import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.DefaultOsxMemoryInfo
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
-import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 @IgnoreIf({ !Platform.current().macOs })
-class OsxMemoryTest extends Specification {
+class OsxMemoryTest extends NativePlatformSpec {
 
     def "caches memory instance"() {
         expect:

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/WindowsMemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/WindowsMemoryTest.groovy
@@ -16,7 +16,6 @@
 
 package net.rubygrapefruit.platform.memory
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Requires
@@ -26,13 +25,13 @@ class WindowsMemoryTest extends NativePlatformSpec {
 
     def "caches memory instance"() {
         expect:
-        def memory = Native.get(WindowsMemory.class)
-        memory.is(Native.get(WindowsMemory.class))
+        def memory = getIntegration(WindowsMemory)
+        memory.is(getIntegration(WindowsMemory))
     }
 
     def "can query Windows memory info"() {
         given:
-        def memory = Native.get(WindowsMemory.class)
+        def memory = getIntegration(WindowsMemory)
 
         when:
         def memoryInfo = memory.memoryInfo

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/WindowsMemoryTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/memory/WindowsMemoryTest.groovy
@@ -17,12 +17,12 @@
 package net.rubygrapefruit.platform.memory
 
 import net.rubygrapefruit.platform.Native
+import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Requires
-import spock.lang.Specification
 
 @Requires({ Platform.current().windows })
-class WindowsMemoryTest extends Specification {
+class WindowsMemoryTest extends NativePlatformSpec {
 
     def "caches memory instance"() {
         expect:

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/terminal/TerminalsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/terminal/TerminalsTest.groovy
@@ -16,7 +16,6 @@
 
 package net.rubygrapefruit.platform.terminal
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativeException
 import net.rubygrapefruit.platform.NativePlatformSpec
 import net.rubygrapefruit.platform.internal.Platform
@@ -26,11 +25,11 @@ import spock.lang.IgnoreIf
 
 class TerminalsTest extends NativePlatformSpec {
     @Rule TemporaryFolder tmpDir
-    final Terminals terminals = Native.get(Terminals.class)
+    final Terminals terminals = getIntegration(Terminals)
 
     def "caches terminals instance"() {
         expect:
-        Native.get(Terminals.class) == terminals
+        getIntegration(Terminals) == terminals
     }
 
     def "can check if attached to terminal"() {

--- a/native-platform/src/test/groovy/net/rubygrapefruit/platform/terminal/TerminalsTest.groovy
+++ b/native-platform/src/test/groovy/net/rubygrapefruit/platform/terminal/TerminalsTest.groovy
@@ -18,13 +18,13 @@ package net.rubygrapefruit.platform.terminal
 
 import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.NativeException
+import net.rubygrapefruit.platform.NativePlatformSpec
+import net.rubygrapefruit.platform.internal.Platform
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.IgnoreIf
 
-class TerminalsTest extends Specification {
+class TerminalsTest extends NativePlatformSpec {
     @Rule TemporaryFolder tmpDir
     final Terminals terminals = Native.get(Terminals.class)
 

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -72,9 +72,13 @@ public class Main {
             System.exit(1);
         }
 
+        File cacheDir;
         if (result.has("cache-dir")) {
-            Native.init(new File(result.valueOf("cache-dir").toString()));
+            cacheDir = new File(result.valueOf("cache-dir").toString());
+        } else {
+            cacheDir = new File("cache-dir");
         }
+        Native.init(cacheDir);
 
         boolean ansi = result.has("ansi");
 

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -49,6 +49,8 @@ import java.util.Date;
 import java.util.List;
 
 public class Main {
+    private static Native nativeIntegration;
+
     public static void main(String[] args) throws Exception {
         OptionParser optionParser = new OptionParser();
         optionParser.accepts("cache-dir", "The directory to cache native libraries in").withRequiredArg();
@@ -78,7 +80,7 @@ public class Main {
         } else {
             cacheDir = new File("cache-dir");
         }
-        Native.init(cacheDir);
+        nativeIntegration = Native.init(cacheDir);
 
         boolean ansi = result.has("ansi");
 
@@ -294,7 +296,7 @@ public class Main {
     }
 
     private static Terminals terminals(boolean ansi) {
-        Terminals terminals = Native.get(Terminals.class);
+        Terminals terminals = nativeIntegration.get(Terminals.class);
         if (ansi) {
             terminals = terminals.withAnsiOutput();
         }
@@ -303,7 +305,7 @@ public class Main {
 
     private static void input() {
         System.out.println();
-        Terminals terminals = Native.get(Terminals.class);
+        Terminals terminals = nativeIntegration.get(Terminals.class);
         if (!terminals.isTerminalInput()) {
             System.out.println("* Input not attached to terminal.");
             return;
@@ -332,15 +334,15 @@ public class Main {
         System.out.println("* JVM: " + System.getProperty("java.vm.vendor") + ' ' + System.getProperty("java.version"));
         System.out.println("* OS (JVM): " + System.getProperty("os.name") + ' ' + System.getProperty("os.version") + ' ' + System.getProperty("os.arch"));
 
-        SystemInfo systemInfo = Native.get(SystemInfo.class);
+        SystemInfo systemInfo = nativeIntegration.get(SystemInfo.class);
         System.out.println("* OS (Kernel): " + systemInfo.getKernelName() + ' ' + systemInfo.getKernelVersion() + ' ' + systemInfo.getArchitectureName() + " (" + systemInfo.getArchitecture() + ")");
         System.out.println("* Hostname: " + systemInfo.getHostname());
 
-        Process process = Native.get(Process.class);
+        Process process = nativeIntegration.get(Process.class);
         System.out.println("* PID: " + process.getProcessId());
 
         try {
-            MemoryInfo memory = Native.get(Memory.class).getMemoryInfo();
+            MemoryInfo memory = nativeIntegration.get(Memory.class).getMemoryInfo();
             System.out.println("* Available memory: " + memory.getAvailablePhysicalMemory());
             System.out.println("* Total memory: " + memory.getTotalPhysicalMemory());
         } catch (NativeIntegrationUnavailableException e) {
@@ -348,7 +350,7 @@ public class Main {
         }
 
         try {
-            WindowsMemoryInfo memory = Native.get(WindowsMemory.class).getMemoryInfo();
+            WindowsMemoryInfo memory = nativeIntegration.get(WindowsMemory.class).getMemoryInfo();
             System.out.println("* Windows Commit Limit: " + memory.getCommitLimit());
             System.out.println("* Windows Commit Total: " + memory.getCommitTotal());
         } catch (NativeIntegrationUnavailableException e) {
@@ -361,7 +363,7 @@ public class Main {
     private static void fileSystems() {
         System.out.println();
 
-        FileSystems fileSystems = Native.get(FileSystems.class);
+        FileSystems fileSystems = nativeIntegration.get(FileSystems.class);
         System.out.println("* File systems: ");
         for (FileSystemInfo fileSystem : fileSystems.getFileSystems()) {
             System.out.println(String.format("    * %s -> %s (type: %s %s, case sensitive: %s, case preserving: %s)",
@@ -383,7 +385,7 @@ public class Main {
     private static void ls(String path, boolean followLinks) {
         File dir = new File(path);
 
-        Files files = Native.get(Files.class);
+        Files files = nativeIntegration.get(Files.class);
         List<? extends DirEntry> entries = files.listDir(dir, followLinks);
         for (DirEntry entry : entries) {
             System.out.println();
@@ -404,7 +406,7 @@ public class Main {
     private static void stat(String path, boolean linkTarget) {
         File file = new File(path);
 
-        Files files = Native.get(Files.class);
+        Files files = nativeIntegration.get(Files.class);
         FileInfo stat = files.stat(file, linkTarget);
         System.out.println();
         System.out.println("* File: " + file);
@@ -427,7 +429,7 @@ public class Main {
 
     private static void stat(File file, PosixFileInfo stat) {
         if (stat.getType() == PosixFileInfo.Type.Symlink) {
-            System.out.println("* Symlink to: " + Native.get(PosixFiles.class).readLink(file));
+            System.out.println("* Symlink to: " + nativeIntegration.get(PosixFiles.class).readLink(file));
         }
         System.out.println("* UID: " + stat.getUid());
         System.out.println("* GID: " + stat.getGid());


### PR DESCRIPTION
Previously we'd implicitly initialize the native integration, causing binaries to be extracted in the system temp directory. This is a security vulnerability and thus is not allowed anymore. Instead we now throw if native integrations are queried without initialization.