### PR TITLE
Add support for linux riscv64

### DIFF
--- a/buildSrc/src/main/java/gradlebuild/JniPlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/JniPlugin.java
@@ -252,6 +252,7 @@ public abstract class JniPlugin implements Plugin<Project> {
             addPlatform(platformContainer, "osx_aarch64", "osx", "aarch64");
             addPlatform(platformContainer, "linux_amd64", "linux", "amd64");
             addPlatform(platformContainer, "linux_aarch64", "linux", "aarch64");
+            addPlatform(platformContainer, "linux_riscv64", "linux", "riscv64");
             addPlatform(platformContainer, "windows_i386", "windows", "i386");
             addPlatform(platformContainer, "windows_amd64", "windows", "amd64");
             addPlatform(platformContainer, "windows_aarch64", "windows", "aarch64");
@@ -266,6 +267,7 @@ public abstract class JniPlugin implements Plugin<Project> {
                     // The core Gradle toolchain for gcc only targets x86 and x86_64 out of the box.
                     // https://github.com/gradle/gradle/blob/36614ee523e5906ddfa1fed9a5dc00a5addac1b0/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
                     toolChain.target("linux_aarch64");
+                    toolChain.target("linux_riscv64");
                 });
             }
             if (toolChainRegistry.stream().noneMatch(toolChain -> toolChain.getName().equals("clang"))) {

--- a/buildSrc/src/main/java/gradlebuild/NcursesPlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/NcursesPlugin.java
@@ -30,7 +30,7 @@ public class NcursesPlugin extends RuleSource {
         if (!os.isLinux()) {
             builder.add(NCURSES_5);
         } else {
-            for (String d : ImmutableList.of("/lib", "/lib64", "/lib/x86_64-linux-gnu", "/lib/aarch64-linux-gnu", "/usr/lib")) {
+            for (String d : ImmutableList.of("/lib", "/lib64", "/lib/x86_64-linux-gnu", "/lib/aarch64-linux-gnu", "/lib/riscv64-linux-gnu", "/usr/lib")) {
                 File libDir = new File(d);
                 if (new File(libDir, "libncurses.so.6").isFile() || new File(libDir, "libncursesw.so.6").isFile()) {
                     builder.add(new NcursesVersion("6"));
@@ -52,6 +52,8 @@ public class NcursesPlugin extends RuleSource {
         addPlatform(platformContainer, "linux_amd64_ncurses6", "linux", "amd64");
         addPlatform(platformContainer, "linux_aarch64_ncurses5", "linux", "aarch64");
         addPlatform(platformContainer, "linux_aarch64_ncurses6", "linux", "aarch64");
+        addPlatform(platformContainer, "linux_riscv64_ncurses5", "linux", "riscv64");
+        addPlatform(platformContainer, "linux_riscv64_ncurses6", "linux", "riscv64");
     }
 
     @Mutate void configureBinaries(@Each NativeBinarySpecInternal binarySpec, Collection<NcursesVersion> ncursesVersions) {
@@ -80,6 +82,8 @@ public class NcursesPlugin extends RuleSource {
             // https://github.com/gradle/gradle/blob/36614ee523e5906ddfa1fed9a5dc00a5addac1b0/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
             toolChain.target("linux_aarch64_ncurses5");
             toolChain.target("linux_aarch64_ncurses6");
+            toolChain.target("linux_riscv64_ncurses5");
+            toolChain.target("linux_riscv64_ncurses6");
         });
     }
 

--- a/native-platform/src/main/cpp/posix.cpp
+++ b/native-platform/src/main/cpp/posix.cpp
@@ -35,7 +35,11 @@
 #include <sys/utsname.h>
 #include <termios.h>
 #include <unistd.h>
-#include <sys/sysctl.h>
+#if defined(__linux__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 32
+    #include <sys/sysinfo.h>
+#else
+    #include <sys/sysctl.h>
+#endif
 
 jmethodID fileStatDetailsMethodId;
 

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/SystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/SystemInfo.java
@@ -21,7 +21,7 @@ package net.rubygrapefruit.platform;
  */
 @ThreadSafe
 public interface SystemInfo extends NativeIntegration {
-    enum Architecture { i386, amd64, aarch64 }
+    enum Architecture { i386, amd64, aarch64, riscv64}
 
     /**
      * Returns the name of the kernel for the current operating system.

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
@@ -62,6 +62,9 @@ public class MutableSystemInfo implements SystemInfo {
         if (machineArchitecture.equals("aarch64") || machineArchitecture.equals("arm64")) {
             return Architecture.aarch64;
         }
+        if (machineArchitecture.equals("riscv64")) {
+            return Architecture.riscv64;
+        }
         throw new NativeException(String.format("Cannot determine architecture from kernel architecture name '%s'.", machineArchitecture));
     }
 

--- a/native-platform/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/native-platform/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -62,6 +62,8 @@ public abstract class Platform {
                         platform = new Linux32Bit();
                     } else if (arch.equals("aarch64")) {
                         platform = new LinuxAarch64();
+                    } else if (arch.equals("riscv64")) {
+                        platform = new LinuxRiscv64();
                     }
                 } else if (osName.contains("os x") || osName.contains("darwin")) {
                     if (arch.equals("i386")) {
@@ -303,6 +305,13 @@ public abstract class Platform {
         @Override
         public String getId() {
             return "linux-aarch64";
+        }
+    }
+
+    private static class LinuxRiscv64 extends Linux {
+        @Override
+        public String getId() {
+            return "linux-riscv64";
         }
     }
 


### PR DESCRIPTION
1. Add RISC-V64 Linux platform support
2. Enable compatibility with glibc-2.32+
3. Verified through successful compilation and test execution on RISC-V Linux.

  Test Results,
```bash
[eta@openeuler-riscv64 bin ]$ ./native-platform-test

Select test to run: Show terminal details

* Stdout: terminal
* Stderr: terminal
* Stdin: terminal
* Terminal implementation: Curses terminal xterm on stdout
* Terminal size: 162 cols x 41 rows
* Text attributes: yes
* Color: yes
* Cursor motion: yes
* Cursor visibility: yes
* Terminal input: POSIX input on stdin
* Raw mode: yes

TEXT ATTRIBUTES
[normal] [bold] [bold+dim] [normal] [dim]

COLORS
bold      bold+dim  bright    normal    dim
[black]   [black]   [black]   [black]   [black]
[red]     [red]     [red]     [red]     [red]
[green]   [green]   [green]   [green]   [green]
[yellow]  [yellow]  [yellow]  [yellow]  [yellow]
[blue]    [blue]    [blue]    [blue]    [blue]
[magenta] [magenta] [magenta] [magenta] [magenta]
[cyan]    [cyan]    [cyan]    [cyan]    [cyan]
[white]   [white]   [white]   [white]   [white]

CURSOR MOVEMENT
[1]       [2]
[3]       [4]
done!

Can write unicode: αβγ ✔


Select test to run: Show machine details

* JVM: Bisheng 11.0.20
* OS (JVM): Linux 6.11.0 riscv64
* OS (Kernel): Linux 6.11.0 riscv64 (riscv64)
* Hostname: openeuler-riscv64
* PID: 14079


Select test to run: Show file systems

* File systems:
    * / -> /dev/root (type: ext4 local, case sensitive: true, case preserving: true)
    * /dev -> devtmpfs (type: devtmpfs local, case sensitive: true, case preserving: true)
    * /proc -> proc (type: proc local, case sensitive: true, case preserving: true)
    * /sys -> sysfs (type: sysfs local, case sensitive: true, case preserving: true)
    * /sys/kernel/security -> securityfs (type: securityfs local, case sensitive: true, case preserving: true)
    * /dev/shm -> tmpfs (type: tmpfs local, case sensitive: true, case preserving: true)
    * /dev/pts -> devpts (type: devpts local, case sensitive: true, case preserving: true)
    * /run -> tmpfs (type: tmpfs local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup -> tmpfs (type: tmpfs local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/systemd -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/bpf -> bpf (type: bpf local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/freezer -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/pids -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/cpuset -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/devices -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/net_cls,net_prio -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/hugetlb -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/perf_event -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/cpu,cpuacct -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/memory -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /sys/fs/cgroup/blkio -> cgroup (type: cgroup local, case sensitive: true, case preserving: true)
    * /dev/hugepages -> hugetlbfs (type: hugetlbfs local, case sensitive: true, case preserving: true)
    * /dev/mqueue -> mqueue (type: mqueue local, case sensitive: true, case preserving: true)
    * /sys/kernel/debug -> none (type: debugfs local, case sensitive: true, case preserving: true)
    * /run/credentials/systemd-sysctl.service -> ramfs (type: ramfs local, case sensitive: true, case preserving: true)
    * /run/credentials/systemd-vconsole-setup.service -> ramfs (type: ramfs local, case sensitive: true, case preserving: true)
    * /sys/kernel/config -> configfs (type: configfs local, case sensitive: true, case preserving: true)
    * /run/credentials/systemd-tmpfiles-setup-dev.service -> ramfs (type: ramfs local, case sensitive: true, case preserving: true)
    * /tmp -> tmpfs (type: tmpfs local, case sensitive: true, case preserving: true)
    * /boot -> /dev/vda1 (type: ext2 local, case sensitive: true, case preserving: true)
    * /run/credentials/systemd-tmpfiles-setup.service -> ramfs (type: ramfs local, case sensitive: true, case preserving: true)
    * /var/lib/nfs/rpc_pipefs -> sunrpc (type: rpc_pipefs local, case sensitive: true, case preserving: true)
    * /run/user/0 -> tmpfs (type: tmpfs local, case sensitive: true, case preserving: true)


Select test to run: Test input handling

* Using default mode
Enter some text: hello world
Character: h (104)
Character: e (101)
Character: l (108)
Character: l (108)
Character: o (111)
Character:   (32)
Character: w (119)
Character: o (111)
Character: r (114)
Character: l (108)
Character: d (100)
Control key: Enter

* Using raw mode
Enter some text (press 'enter' to finish):
Character: a (97)
Character: b (98)
Control key: Enter


Select test to run: Example prompts

Select an option: Option 1

Enter some text: hello world

Enter a password: [hidden]

A yes/no question: yes

You selected item: Option 1
You entered: [hello world]
You entered: [123456]
You answered: yes


Select test to run: Exit
```