### PR TITLE
Compile to Java 8 for native platform

### DIFF
--- a/buildSrc/src/main/java/gradlebuild/VersioningPlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/VersioningPlugin.java
@@ -1,6 +1,5 @@
 package gradlebuild;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.provider.ProviderFactory;
@@ -32,9 +31,6 @@ public abstract class VersioningPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         VersionDetails.BuildType buildType = determineBuildType(project);
-        if (buildType != VersionDetails.BuildType.Dev && JavaVersion.current() != JavaVersion.VERSION_1_8) {
-            throw new RuntimeException("Java 8 is required to build a release of native-platform. Later versions are not supported.");
-        }
         String buildTimestamp = determineBuildTimestamp(project);
         writeBuildTimestamp(buildTimestamp, project);
         String version = determineVersion(buildType, buildTimestamp);

--- a/native-platform/build.gradle
+++ b/native-platform/build.gradle
@@ -76,5 +76,6 @@ java {
 }
 
 tasks.withType(JavaCompile).configureEach {
+    // Release to 8, since it's used in gradle/gradle in workers
     options.release = 8
 }

--- a/native-platform/build.gradle
+++ b/native-platform/build.gradle
@@ -75,3 +75,6 @@ java {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -41,10 +41,11 @@ publishing {
 
 // Download and unpack the application to allow it to be tested
 tasks.register('download') {
+    def downloadDir = project.layout.buildDirectory.dir("download")
     doLast {
         copy {
             from(configurations.download.files.collect { zipTree(it) })
-            into("$buildDir/download")
+            into(downloadDir)
         }
     }
 }
@@ -52,4 +53,11 @@ tasks.register('download') {
 // Use System.in as input stream for the launched process to enable interactive input
 tasks.named("run", JavaExec) {
     standardInput = System.in
+}
+
+java {
+    toolchain {
+        // Configure Java 8, so we test that native-platform is compiled to Java 8
+        languageVersion = JavaLanguageVersion.of(8)
+    }
 }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -40,7 +40,7 @@ publishing {
 }
 
 // Download and unpack the application to allow it to be tested
-task download {
+tasks.register('download') {
     doLast {
         copy {
             from(configurations.download.files.collect { zipTree(it) })


### PR DESCRIPTION
Since we use it in gradle/gradle for in example [process-memory-services](https://github.com/gradle/gradle/blob/4cb26df97ce64a9ca2804342a9646a615527bff8/platforms/core-runtime/process-memory-services/build.gradle.kts#L26) that is [used for workers](https://github.com/gradle/gradle/blob/4cb26df97ce64a9ca2804342a9646a615527bff8/platforms/core-runtime/process-memory-services/build.gradle.kts#L7-L11) that can run on Java 8.