### PR TITLE
Move UbuntuAmd64 CI to Ubuntu 24.04 EC2 agents

### DIFF
--- a/.teamcity/Agent.kt
+++ b/.teamcity/Agent.kt
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-enum class Agent(val os: Os, val architecture: Architecture) {
-    UbuntuAmd64(os = Os.Ubuntu16, architecture = Architecture.Amd64),
+enum class Agent(val os: Os, val architecture: Architecture, val nativePublishContainer: String? = null) {
+    UbuntuAmd64(
+        os = Os.Ubuntu24,
+        architecture = Architecture.Amd64,
+        nativePublishContainer = "native-platform/ubuntu16-publish:local",
+    ),
     UbuntuAarch64(os = Os.Ubuntu16, architecture = Architecture.Aarch64),
     AmazonLinuxAmd64(os = Os.AmazonLinux, architecture = Architecture.Amd64),
     AmazonLinuxAarch64(os = Os.AmazonLinux, architecture = Architecture.Aarch64),

--- a/.teamcity/NativePlatformBuild.kt
+++ b/.teamcity/NativePlatformBuild.kt
@@ -32,13 +32,32 @@ open class NativePlatformBuild(agent: Agent, buildReceiptSource: Boolean = false
     }
 
     steps {
+        val publishOnHost = agent.nativePublishContainer.isNullOrBlank() || agent.allPublishTasks.isBlank()
+        if (!publishOnHost) {
+            buildNativePublishContainerImage(agent)
+        }
+
         gradle {
-            tasks =
-                "clean build -PagentName=${agent.name}${agent.allPublishTasks} ${javaInstallationLocations()}"
+            tasks = buildString {
+                append("clean build -PagentName=${agent.name}")
+                if (publishOnHost) {
+                    append(agent.allPublishTasks)
+                }
+                append(" ${javaInstallationLocations()}")
+            }
             if (buildReceiptSource) {
                 gradleParams = "-PignoreIncomingBuildReceipt"
             }
             buildFile = ""
+        }
+
+        if (!publishOnHost) {
+            gradle {
+                name = "Publish (glibc 2.23 container)"
+                tasks = "${agent.allPublishTasks.trim()} ${javaInstallationLocations()}"
+                useNativePublishContainer(agent)
+                buildFile = ""
+            }
         }
     }
 

--- a/.teamcity/NativePlatformPublishing.kt
+++ b/.teamcity/NativePlatformPublishing.kt
@@ -91,11 +91,20 @@ open class NativePlatformPublishSnapshot(
     }
 
     steps {
+        val usesNativePublishContainer = !agent.nativePublishContainer.isNullOrBlank() &&
+            uploadTasks.any { it.isNativePublishTask() }
+        if (usesNativePublishContainer) {
+            buildNativePublishContainerImage(agent)
+        }
+
         uploadTasks.forEach { task ->
             gradle {
                 name = "Gradle $task"
                 tasks =
                     "clean $task -P${releaseType.gradleProperty}${if (releaseType.userProvidedVersion) "=%versionPostfix%" else ""} ${javaInstallationLocations()}"
+                if (usesNativePublishContainer && task.isNativePublishTask()) {
+                    useNativePublishContainer(agent)
+                }
                 buildFile = ""
             }
         }

--- a/.teamcity/Os.kt
+++ b/.teamcity/Os.kt
@@ -27,6 +27,13 @@ interface Os {
         }
     }
 
+    object Ubuntu24 : Linux(Ncurses.Ncurses6) {
+        override fun Requirements.additionalRequirements() {
+            contains(osDistributionNameParameter, "ubuntu")
+            contains(osDistributionVersionParameter, "24")
+        }
+    }
+
     object AmazonLinux : Linux(Ncurses.Ncurses6) {
         override fun Requirements.additionalRequirements() {
             contains(osDistributionNameParameter, "amazon")

--- a/.teamcity/docker/native-publish-ubuntu16/Dockerfile
+++ b/.teamcity/docker/native-publish-ubuntu16/Dockerfile
@@ -1,0 +1,25 @@
+# Released native-platform Linux libraries must stay on glibc 2.23 (Ubuntu 16.04).
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    g++ \
+    git \
+    libncurses5-dev \
+    openjdk-8-jdk \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG JDK21_VERSION=jdk-21.0.11+10
+RUN mkdir -p /opt/jdk \
+    && curl -fsSL "https://api.adoptium.net/v3/binary/version/${JDK21_VERSION}/linux/x64/jdk/hotspot/normal/adoptium" -o /tmp/jdk21.tar.gz \
+    && tar xf /tmp/jdk21.tar.gz -C /opt/jdk \
+    && ln -s "/opt/jdk/${JDK21_VERSION}" /opt/jdk/open-jdk-21 \
+    && rm /tmp/jdk21.tar.gz
+
+ENV JDK8=/usr/lib/jvm/java-8-openjdk-amd64
+ENV JDK21=/opt/jdk/open-jdk-21
+ENV JAVA_HOME=/opt/jdk/open-jdk-21

--- a/.teamcity/extensions.kt
+++ b/.teamcity/extensions.kt
@@ -16,10 +16,13 @@
 
 import jetbrains.buildServer.configs.kotlin.BuildFeatures
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.Requirements
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildFeatures.freeDiskSpace
+import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 fun Requirements.requireAgent(agent: Agent) {
     agent.os.addAgentRequirements(this)
@@ -97,3 +100,26 @@ fun BuildFeatures.lowerRequiredFreeDiskSpace() {
         failBuild = false
     }
 }
+
+private const val nativePublishContainerDockerfile = ".teamcity/docker/native-publish-ubuntu16"
+
+fun BuildSteps.buildNativePublishContainerImage(agent: Agent) {
+    val containerImage = agent.nativePublishContainer ?: return
+    script {
+        name = "Build native publish container image"
+        scriptContent = """
+            #!/bin/bash
+            set -euo pipefail
+            docker build -t $containerImage $nativePublishContainerDockerfile
+        """.trimIndent()
+    }
+}
+
+fun GradleBuildStep.useNativePublishContainer(agent: Agent) {
+    val containerImage = agent.nativePublishContainer ?: return
+    dockerImage = containerImage
+    dockerPull = false
+}
+
+fun String.isNativePublishTask(): Boolean =
+    contains("uploadJni") || contains("uploadNcurses")


### PR DESCRIPTION
Part of migrating native-platform EC2 build agents into the **gradle-bt-ci** AWS account (us-west-2). First target AMI: `ami-041694c5c8e7cbe51` (`ec2-ubuntu24-amd64-build-vm`, tag `native-platform=ubuntu24-amd64`).

## Summary
- `UbuntuAmd64`: `Os.Ubuntu16` → `Os.Ubuntu24` so builds match agents reporting Ubuntu 24.04
- Split CI publish work: tests/build run on the Ubuntu 24 host; `:native-platform:uploadJni` (and other native publish tasks) run inside an Ubuntu 16.04 container to preserve the shipped **glibc 2.23** runtime floor
- Add `.teamcity/docker/native-publish-ubuntu16/Dockerfile` used by TeamCity to build the publish container on the agent

## Why the container is required
Unlike gradle-fileevents (Linux agents are test-only), native-platform's `UbuntuAmd64` agent builds **released** JNI artifacts (`uploadJni`, `uploadMain`). Building those directly on Ubuntu 24.04 would raise the glibc floor to 2.39 and break Gradle on older Linux distros. See the migration plan in dev-infrastructure.

## Cutover dependencies (do not merge until done)
1. **TeamCity cloud image** — add/update `Ubuntu 24 AMD64` in the native-platform agents cloud profile to `ami-041694c5c8e7cbe51` (us-west-2, gradle-bt-ci account `114865652559`). The profile currently has Ubuntu 24 **AArch64** but not AMD64 with this AMI.
2. **Agent pool** — ensure the profile serves the `GradleNative_NativePlatform` project pool with instance types that have NVMe instance store (e.g. `c6id.*`); the new AMI self-terminates without ≥50 GB instance store.
3. **UbuntuAarch64** — still on `Os.Ubuntu16` in this PR; migrate separately once `ami-054be1e2616d069a1` is ready.

## Test plan
- [ ] Register/update TeamCity cloud image `Ubuntu 24 AMD64 (ami-041694c5c8e7cbe51)` in us-west-2
- [ ] Trigger `Test on UbuntuAmd64` on this branch and confirm an Ubuntu 24 EC2 agent is provisioned
- [ ] Verify host build step passes on Ubuntu 24.04
- [ ] Verify publish step runs in the Ubuntu 16.04 container and uploads JNI artifacts
- [ ] Confirm other agent builds (`UbuntuAarch64`, Amazon Linux, etc.) are unaffected