### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/.teamcity/NativePlatformPublishing.kt
+++ b/.teamcity/NativePlatformPublishing.kt
@@ -81,6 +81,7 @@ open class NativePlatformPublishSnapshot(
         param("env.GRADLE_INTERNAL_REPO_URL", "%gradle.internal.repository.url%")
         param("env.ORG_GRADLE_PROJECT_publishUserName", "%ARTIFACTORY_USERNAME%")
         param("env.ORG_GRADLE_PROJECT_publishApiKey", "%ARTIFACTORY_PASSWORD%")
+        param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
     }

--- a/buildSrc/src/main/java/gradlebuild/ReleasePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/ReleasePlugin.java
@@ -56,7 +56,8 @@ public class ReleasePlugin implements Plugin<Project> {
             sign.setEnabled(signArtifacts);
         });
         project.getExtensions().configure(SigningExtension.class, signing -> {
-            signing.useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"));
+            // Key ID required when signing with a subkey
+            signing.useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY_ID"), System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"));
             project.getExtensions().getByType(PublishingExtension.class).getPublications().configureEach(publication -> {
                 if (signArtifacts) {
                     signing.sign(publication);


### PR DESCRIPTION
After the move to a signing subkey following the August 14 security incident, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key.

This adds the key ID to the `signing {}` block and, where the repo owns the build configuration, makes it pass `env.PGP_SIGNING_KEY_ID`. Matches gradle/gradle#38874 and the other Gradle-org repos.

The `pgpSigningKeyId` parameter is already inherited from the parent TeamCity project, so no new secret is needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321