### PR TITLE
Publish to Artifactory with a Bearer token

### DIFF
--- a/.teamcity/NativePlatformPublishing.kt
+++ b/.teamcity/NativePlatformPublishing.kt
@@ -73,14 +73,12 @@ open class NativePlatformPublishSnapshot(
     init: BuildType.() -> Unit
 ) : BuildType({
     params {
-        param("ARTIFACTORY_USERNAME", releaseType.username)
-        password("ARTIFACTORY_PASSWORD", releaseType.password, display = ParameterDisplay.HIDDEN)
+        password("ARTIFACTORY_TOKEN", releaseType.token, display = ParameterDisplay.HIDDEN)
         if (releaseType.userProvidedVersion) {
             text("reverse.dep.*.$versionPostfixParameterName", "${releaseType.gradleProperty}-1", display = ParameterDisplay.PROMPT, allowEmpty = false)
         }
         param("env.GRADLE_INTERNAL_REPO_URL", "%gradle.internal.repository.url%")
-        param("env.ORG_GRADLE_PROJECT_publishUserName", "%ARTIFACTORY_USERNAME%")
-        param("env.ORG_GRADLE_PROJECT_publishApiKey", "%ARTIFACTORY_PASSWORD%")
+        password("env.ORG_GRADLE_PROJECT_publishToken", "%ARTIFACTORY_TOKEN%")
         param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")

--- a/.teamcity/ReleaseType.kt
+++ b/.teamcity/ReleaseType.kt
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-const val gradleInternalRepositoryUsername = "%gradle.internal.repository.build-tool.publish.username%"
-const val gradleInternalRepositoryPassword = "%gradle.internal.repository.build-tool.publish.password%"
+const val gradleInternalRepositoryToken = "%gradle.internal.repository.build-tool.publish.token%"
 
-enum class ReleaseType(val gradleProperty: String, val username: String, val password: String, val userProvidedVersion: Boolean = false) {
-    Snapshot("snapshot", gradleInternalRepositoryUsername, gradleInternalRepositoryPassword),
-    Alpha("alpha", gradleInternalRepositoryUsername, gradleInternalRepositoryPassword, true),
-    Milestone("milestone", gradleInternalRepositoryUsername, gradleInternalRepositoryPassword),
-    Release("release", gradleInternalRepositoryUsername, gradleInternalRepositoryPassword)
+enum class ReleaseType(val gradleProperty: String, val token: String, val userProvidedVersion: Boolean = false) {
+    Snapshot("snapshot", gradleInternalRepositoryToken),
+    Alpha("alpha", gradleInternalRepositoryToken, true),
+    Milestone("milestone", gradleInternalRepositoryToken),
+    Release("release", gradleInternalRepositoryToken)
 }

--- a/buildSrc/src/main/java/gradlebuild/PublishPlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/PublishPlugin.java
@@ -3,6 +3,7 @@ package gradlebuild;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.credentials.HttpHeaderCredentials;
 import org.gradle.api.plugins.BasePluginExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.Publication;
@@ -11,6 +12,7 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.authentication.http.HttpHeaderAuthentication;
 
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -18,8 +20,7 @@ import java.util.stream.Stream;
 
 public class PublishPlugin implements Plugin<Project> {
     public static final String LOCAL_FILE_REPOSITORY_NAME = "LocalFile";
-    private static final String PUBLISH_USER_NAME_PROPERTY = "publishUserName";
-    private static final String PUBLISH_API_KEY_PROPERTY = "publishApiKey";
+    private static final String PUBLISH_TOKEN_PROPERTY = "publishToken";
 
     @Override
     public void apply(Project project) {
@@ -83,20 +84,18 @@ public class PublishPlugin implements Plugin<Project> {
             .forEach(repository -> repositories.maven(repo -> {
                 repo.setUrl(repository.getUrl());
                 repo.setName(repository.name());
-                repo.credentials(passwordCredentials -> {
-                    passwordCredentials.setUsername(credentials.getUserName());
-                    passwordCredentials.setPassword(credentials.getApiKey());
+                repo.credentials(HttpHeaderCredentials.class, headerCredentials -> {
+                    headerCredentials.setName("Authorization");
+                    headerCredentials.setValue("Bearer " + credentials.getToken());
                 });
+                repo.getAuthentication().create("header", HttpHeaderAuthentication.class);
             }));
     }
 
     private PublishRepositoryCredentials configureCredentials(Project project) {
         PublishRepositoryCredentials credentials = project.getExtensions().create("publishRepository", PublishRepositoryCredentials.class);
-        if (project.hasProperty(PUBLISH_USER_NAME_PROPERTY)) {
-            credentials.setUserName(project.property(PUBLISH_USER_NAME_PROPERTY).toString());
-        }
-        if (project.hasProperty(PUBLISH_API_KEY_PROPERTY)) {
-            credentials.setApiKey(project.property(PUBLISH_API_KEY_PROPERTY).toString());
+        if (project.hasProperty(PUBLISH_TOKEN_PROPERTY)) {
+            credentials.setToken(project.property(PUBLISH_TOKEN_PROPERTY).toString());
         }
         return credentials;
     }

--- a/buildSrc/src/main/java/gradlebuild/PublishRepositoryCredentials.java
+++ b/buildSrc/src/main/java/gradlebuild/PublishRepositoryCredentials.java
@@ -1,34 +1,22 @@
 package gradlebuild;
 
 /**
- * Credentials for accessing the repository for publishing. Only required when releasing.
+ * Token for accessing the repository for publishing. Only required when releasing.
  */
 public class PublishRepositoryCredentials {
-    private String userName;
-    private String apiKey;
+    private String token;
 
-    public String getUserName() {
-        return userName;
+    public String getToken() {
+        return token;
     }
 
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
-    public String getApiKey() {
-        return apiKey;
-    }
-
-    public void setApiKey(String apiKey) {
-        this.apiKey = apiKey;
+    public void setToken(String token) {
+        this.token = token;
     }
 
     void assertPresent() {
-        if (userName == null) {
-            throw new IllegalStateException("No publish repository user name specified. You can set project property 'publishUserName' to provide this.");
-        }
-        if (apiKey == null) {
-            throw new IllegalStateException("No publish repository API key specified. You can set project property 'publishApiKey' to provide this.");
+        if (token == null) {
+            throw new IllegalStateException("No publish repository token specified. You can set project property 'publishToken' to provide this.");
         }
     }
 }

--- a/buildSrc/src/main/java/gradlebuild/ReleasePlugin.java
+++ b/buildSrc/src/main/java/gradlebuild/ReleasePlugin.java
@@ -6,7 +6,8 @@ import org.gradle.api.Task;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.authentication.http.BasicAuthentication;
+import org.gradle.api.credentials.HttpHeaderCredentials;
+import org.gradle.authentication.http.HttpHeaderAuthentication;
 import org.gradle.plugins.signing.Sign;
 import org.gradle.plugins.signing.SigningExtension;
 
@@ -42,9 +43,11 @@ public class ReleasePlugin implements Plugin<Project> {
             credentials.assertPresent();
             project.getRepositories().maven(repo -> {
                 repo.setUrl(releaseRepository.getUrl());
-                repo.getCredentials().setUsername(credentials.getUserName());
-                repo.getCredentials().setPassword(credentials.getApiKey());
-                repo.getAuthentication().create("basic", BasicAuthentication.class);
+                repo.credentials(HttpHeaderCredentials.class, headerCredentials -> {
+                    headerCredentials.setName("Authorization");
+                    headerCredentials.setValue("Bearer " + credentials.getToken());
+                });
+                repo.getAuthentication().create("header", HttpHeaderAuthentication.class);
             });
         });
 

--- a/readme.md
+++ b/readme.md
@@ -353,13 +353,13 @@ To publish manually:
 2. Create a tag
 3. Build each variant.
     1. Checkout tag.
-    2. `./gradlew clean :native-platform:test :native-platform:uploadJni -Prelease -PpublishUserName=<> -PpublishApiKey=<>`.
+    2. `./gradlew clean :native-platform:test :native-platform:uploadJni -Prelease -PpublishToken=<>`.
 4. Build Java library:
     1. Checkout tag.
-    2. `./gradlew clean :native-platform:test :native-platform:uploadMain -Prelease -PpublishUserName=<> -PpublishApiKey=<>`
+    2. `./gradlew clean :native-platform:test :native-platform:uploadMain -Prelease -PpublishToken=<>`
 5. Build the test app:
     1. Checkout tag.
-    2. `./gradlew clean :test-app:uploadMain -Prelease -PpublishUserName=<> -PpublishApiKey=<>`
+    2. `./gradlew clean :test-app:uploadMain -Prelease -PpublishToken=<>`
 6. Publish on bintray
 7. Checkout master
 8. Increment version number in `gradle.properties` and this readme.


### PR DESCRIPTION
## Summary
- Replace `publishUserName` / `publishApiKey` with a single `publishToken`.
- Authenticate publish and release-repo resolution with `Authorization: Bearer`.

Depends on https://github.com/gradle/develocity-artifactory/pull/344. Do not merge until that token is applied and copied into the TeamCity Root param `gradle.internal.repository.build-tool.publish.token`.

## Test plan
- [ ] TeamCity Root has `gradle.internal.repository.build-tool.publish.token` set
- [ ] A snapshot publish job uploads to `libs-snapshots-local`
- [ ] Manual publish with `-PpublishToken=` still works